### PR TITLE
Remove English full-name editable filed

### DIFF
--- a/src/actions/profile.actions.ts
+++ b/src/actions/profile.actions.ts
@@ -75,19 +75,6 @@ export async function setIntellectAgreement(agree: boolean) {
   }
 }
 
-export async function updateEnglishFullName(fullNameEnglish: string) {
-  try {
-    await campusFetch('profile', {
-      method: 'PUT',
-      body: JSON.stringify({ fullNameEnglish }),
-    });
-
-    revalidatePath('/profile');
-  } catch (error) {
-    throw new Error('Error while updating English full name');
-  }
-}
-
 export async function updateIntellectInfo(credo: string, scientificInterests: string) {
   try {
     await campusFetch('profile/intellect', {

--- a/src/app/[locale]/(private)/greeting.tsx
+++ b/src/app/[locale]/(private)/greeting.tsx
@@ -1,8 +1,7 @@
 import { getUserDetails } from '@/actions/auth.actions';
 import { Heading1 } from '@/components/typography/headers';
-import { LOCALE } from '@/i18n/routing';
 import { cn } from '@/lib/utils';
-import { getLocale, getTranslations } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
 interface GreetingProps {
   className?: string;
@@ -10,10 +9,9 @@ interface GreetingProps {
 
 export default async function Greeting({ className }: GreetingProps) {
   const user = await getUserDetails();
-  const locale = await getLocale();
   const t = await getTranslations('private.main');
 
-  const fullName = locale === LOCALE.EN ? user?.fullNameEnglish : user?.fullName;
+  const fullName = user?.fullName;
 
   return <Heading1 className={cn(className)}>{t('welcome', { name: fullName })}</Heading1>;
 }

--- a/src/app/[locale]/(private)/profile/components/info-block.tsx
+++ b/src/app/[locale]/(private)/profile/components/info-block.tsx
@@ -12,7 +12,6 @@ import React from 'react';
 import { LecturerInfo } from '@/app/[locale]/(private)/profile/components/lecturer-info';
 import { StudentInfo } from '@/app/[locale]/(private)/profile/components/student-info';
 import { ProfilePicture } from '@/components/ui/profile-picture';
-import { EditableField } from '@/app/[locale]/(private)/profile/components/editable-field';
 
 interface Props {
   user: User;

--- a/src/app/[locale]/(private)/profile/components/info-block.tsx
+++ b/src/app/[locale]/(private)/profile/components/info-block.tsx
@@ -5,7 +5,6 @@ import { cn } from '@/lib/utils';
 import { Heading4, Heading6 } from '@/components/typography/headers';
 import { useTranslations } from 'next-intl';
 import { Separator } from '@/components/ui/separator';
-import { updateEnglishFullName } from '@/actions/profile.actions';
 import { Badge } from '@/components/ui/badge';
 import { User } from '@/types/models/user';
 import { USER_CATEGORIES } from '@/lib/constants/user-category';
@@ -27,10 +26,6 @@ export function InfoBlock({ user, className }: Props) {
   const studentProfile = user?.studentProfile;
   const employeeProfile = user?.employeeProfile;
 
-  const handleSaveFullNameEn = async (newName: string) => {
-    await updateEnglishFullName(newName);
-  };
-
   return (
     <Card className={cn(className)}>
       <CardContent className="flex flex-col gap-6 space-y-1.5 p-9">
@@ -38,14 +33,6 @@ export function InfoBlock({ user, className }: Props) {
           <ProfilePicture size="xl" src={user.photo || ''} />
           <div className="flex flex-col gap-4 md:gap-2">
             <Heading4>{user.fullName}</Heading4>
-            <EditableField
-              disableClearValue
-              size="small"
-              value={user.fullNameEnglish || ''}
-              onSave={handleSaveFullNameEn}
-              renderValue={(value: string) => <Heading6>{value}</Heading6>}
-              placeholder={t('info.full-name-EN')}
-            />
             <div className="flex gap-2">
               {user.userCategories.map((category) => (
                 <Heading6 key={category} className="text-basic-blue">

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -293,7 +293,6 @@
         "education-form": "Form of study",
         "study-year": "Study year",
         "speciality": "Speciality",
-        "full-name-EN": "Full name in English",
         "academic-degree": "Academic degree",
         "academic-status": "Academic title",
         "position": "Position",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -291,7 +291,7 @@
         "group": "Group",
         "grade-book": "Grade book number",
         "education-form": "Form of study",
-        "study-year": "Study year:",
+        "study-year": "Study year",
         "speciality": "Speciality",
         "full-name-EN": "Full name in English",
         "academic-degree": "Academic degree",

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -293,7 +293,6 @@
         "education-form": "Форма навчання",
         "study-year": "Курс навчання",
         "speciality": "Спеціальність",
-        "full-name-EN": "ПІБ(англійською)",
         "academic-degree": "Науковий ступінь",
         "academic-status": "Вчене звання",
         "position": "Посада",

--- a/src/types/models/user.ts
+++ b/src/types/models/user.ts
@@ -9,7 +9,6 @@ export interface User {
   scientificInterests?: string;
   userIdentifier: string;
   fullName: string;
-  fullNameEnglish: string;
   photo: string;
   credo: string;
   sid: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the option to edit the English full name in the user profile for a simplified experience.
- **Style**
	- Updated the study year label by removing the trailing colon for a cleaner display.
- **Bug Fixes**
	- Eliminated locale-dependent logic for displaying the user's full name, streamlining the user experience.
- **Chores**
	- Removed outdated localization keys related to the English full name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->