### PR TITLE
KB-374 update profile picture in header after re-upload in settings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+language: "en-US"
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: [master, main, dev]

--- a/src/actions/settings.actions.ts
+++ b/src/actions/settings.actions.ts
@@ -19,6 +19,7 @@ export async function changeEmail(email: string) {
 
 export async function changePhoto(formData: FormData) {
   await fileUpload('profile/photo', formData);
+  revalidatePath('/');
 }
 
 export async function changePassword(password: string, currentPassword: string) {

--- a/src/app/[locale]/(private)/header.tsx
+++ b/src/app/[locale]/(private)/header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { sleep, uid } from 'radash';
 import { LocaleSwitch } from '@/components/ui/locale-switch';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { ProfilePicture } from '@/components/ui/profile-picture';
@@ -17,7 +18,7 @@ import { USER_CATEGORIES } from '@/lib/constants/user-category';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface Props {
-  user: User | null;
+  user: User;
 }
 
 export const Header: FC<Props> = ({ user }) => {
@@ -25,6 +26,29 @@ export const Header: FC<Props> = ({ user }) => {
 
   const t = useTranslations('private.profile');
   const tUserCategory = useTranslations('global.user-category');
+  const [profilePhoto, setProfilePhoto] = useState('');
+  const firstRender = useRef(true);
+
+  // This is to update profile picture when it's been uploaded in profile settings.
+  // Photo is cached on CDN level, but the link to it is always the same.
+  // We need to wait several seconds after image upload. During this time the cache is purged.
+  // Then we re-render component with an updated link with a random parameter, which is
+  // propagated to CDN url via campus backend.
+  useEffect(() => {
+    const setProfilePhotoUrl = () => setProfilePhoto(`${user.photo}?v=${uid(8)}`);
+
+    const deferProfileImageUpdate = async () => {
+      await sleep(5000);
+      setProfilePhotoUrl();
+    };
+
+    if (firstRender.current) {
+      setProfilePhotoUrl();
+      firstRender.current = false;
+    } else {
+      deferProfileImageUpdate();
+    }
+  }, [user]);
 
   const handleLogout = async () => {
     await logout();
@@ -42,7 +66,7 @@ export const Header: FC<Props> = ({ user }) => {
       <div className="flex items-center gap-8">
         <LocaleSwitch />
         <div className="flex items-center gap-3">
-          <ProfilePicture size="sm" src={user?.photo || ''} />
+          <ProfilePicture size="sm" src={profilePhoto} />
           <div className="hidden flex-col md:flex">
             <Paragraph className="m-0 text-base font-medium">{user?.username}</Paragraph>
             {user?.userCategories.map((category) => (

--- a/src/app/[locale]/(private)/header.tsx
+++ b/src/app/[locale]/(private)/header.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import React, { FC, useEffect, useRef, useState } from 'react';
-import { sleep, uid } from 'radash';
+import { sleep } from 'radash';
 import { LocaleSwitch } from '@/components/ui/locale-switch';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { ProfilePicture } from '@/components/ui/profile-picture';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Show } from '@/components/utils/show';
-import { cn } from '@/lib/utils';
+import { cn, getUniqueUserPhotoUrl } from '@/lib/utils';
 import { User } from '@/types/models/user';
 import { Button } from '@/components/ui/button';
 import { logout } from '@/actions/auth.actions';
@@ -35,7 +35,7 @@ export const Header: FC<Props> = ({ user }) => {
   // Then we re-render component with an updated link with a random parameter, which is
   // propagated to CDN url via campus backend.
   useEffect(() => {
-    const setProfilePhotoUrl = () => setProfilePhoto(`${user.photo}?v=${uid(8)}`);
+    const setProfilePhotoUrl = () => setProfilePhoto(getUniqueUserPhotoUrl(user.photo));
 
     const deferProfileImageUpdate = async () => {
       await sleep(5000);

--- a/src/app/[locale]/(private)/layout.tsx
+++ b/src/app/[locale]/(private)/layout.tsx
@@ -2,6 +2,7 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/app-sidebar/app-sidebar';
 import { Header } from './header';
 import { getUserDetails } from '@/actions/auth.actions';
+import { notFound } from 'next/navigation';
 
 export default async function MainPageLayout({
   children,
@@ -9,6 +10,10 @@ export default async function MainPageLayout({
   children: React.ReactNode;
 }>) {
   const user = await getUserDetails();
+
+  if (!user) {
+    notFound();
+  }
 
   return (
     <SidebarProvider>

--- a/src/app/[locale]/(private)/settings/page.tsx
+++ b/src/app/[locale]/(private)/settings/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server';
 import { SettingsForm } from '@/app/[locale]/(private)/settings/settings-form';
 import { Paragraph } from '@/components/typography/paragraph';
 import { getUserDetails } from '@/actions/auth.actions';
+import { notFound } from 'next/navigation';
 
 const INTL_NAMESPACE = 'private.settings';
 
@@ -18,6 +19,10 @@ export async function generateMetadata({ params: { locale } }: { params: { local
 export default async function SettingsPage() {
   const t = await getTranslations(INTL_NAMESPACE);
   const user = await getUserDetails();
+
+  if (!user) {
+    notFound();
+  }
 
   return (
     <SubLayout pageTitle={t('title')}>

--- a/src/app/[locale]/(private)/settings/settings-form.tsx
+++ b/src/app/[locale]/(private)/settings/settings-form.tsx
@@ -17,7 +17,7 @@ import { changeEmail, changePassword, changePhoto } from '@/actions/settings.act
 import { useIsMobile } from '@/hooks/use-mobile';
 import { PhotoUploader } from '@/app/[locale]/(private)/settings/photo-uploader';
 import { toast } from '@/hooks/use-toast';
-import { uid } from 'radash';
+import { getUniqueUserPhotoUrl } from '@/lib/utils';
 
 interface Props {
   user: User;
@@ -28,7 +28,7 @@ export function SettingsForm({ user }: Props) {
   const isMobile = useIsMobile();
   const t = useTranslations('private.settings');
   const [file, setFile] = useState<File | null>(null);
-  const profilePhoto = `${user.photo}?v=${uid(8)}`;
+  const profilePhoto = getUniqueUserPhotoUrl(user.photo);
 
   const FormSchema = z
     .object({

--- a/src/app/[locale]/(private)/settings/settings-form.tsx
+++ b/src/app/[locale]/(private)/settings/settings-form.tsx
@@ -17,19 +17,18 @@ import { changeEmail, changePassword, changePhoto } from '@/actions/settings.act
 import { useIsMobile } from '@/hooks/use-mobile';
 import { PhotoUploader } from '@/app/[locale]/(private)/settings/photo-uploader';
 import { toast } from '@/hooks/use-toast';
+import { uid } from 'radash';
 
 interface Props {
-  user: User | null;
+  user: User;
 }
 
 export function SettingsForm({ user }: Props) {
   const { errorToast } = useServerErrorToast();
-
   const isMobile = useIsMobile();
-
   const t = useTranslations('private.settings');
-
   const [file, setFile] = useState<File | null>(null);
+  const profilePhoto = `${user.photo}?v=${uid(8)}`;
 
   const FormSchema = z
     .object({
@@ -52,7 +51,7 @@ export function SettingsForm({ user }: Props) {
   const form = useForm({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      email: user?.email || '',
+      email: user.email || '',
       currentPassword: '',
       newPassword: '',
       confirmPassword: '',
@@ -61,7 +60,7 @@ export function SettingsForm({ user }: Props) {
 
   const handleFormSubmit = async (data: FormData) => {
     try {
-      if (user?.email !== data.email) {
+      if (user.email !== data.email) {
         await changeEmail(data.email);
       }
 
@@ -90,7 +89,7 @@ export function SettingsForm({ user }: Props) {
     <Card>
       <CardContent className="flex flex-col gap-8 space-y-1.5 p-10">
         <Heading5>{t('section.photo')}</Heading5>
-        <PhotoUploader photoSrc={user?.photo || ''} onFileUpload={setFile} />
+        <PhotoUploader photoSrc={profilePhoto} onFileUpload={setFile} />
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleFormSubmit)} className="flex flex-col items-start space-y-4">
             <Heading5>{t('section.contacts')}</Heading5>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,9 @@
 import { clsx, type ClassValue } from 'clsx';
+import { uid } from 'radash';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const getUniqueUserPhotoUrl = (profileUrl: string) => `${profileUrl}?v=${uid(8)}`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic cache refresh for the homepage after updating your profile photo, ensuring immediate visibility of changes.
  - Improved handling of profile photo updates with cache-busting, so your new photo appears promptly across the app.

- **Bug Fixes**
  - Prevented access to the settings and private pages when user data is unavailable, displaying a "Page Not Found" error instead.

- **Chores**
  - Introduced a configuration file to enable automated review processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->