### PR TITLE
Hotfix: translation key for tab title in study sheet page

### DIFF
--- a/src/app/[locale]/(private)/module/studysheet/[id]/page.tsx
+++ b/src/app/[locale]/(private)/module/studysheet/[id]/page.tsx
@@ -23,7 +23,7 @@ export default function InfoPageClient() {
   const { id } = useParams();
   const searchParams = useSearchParams();
   const t = useTranslations('private.study-sheet');
-  const tTab = useTranslations(`private.study-sheet.sheet`);
+  const tTab = useTranslations(`private.study-sheet.tab`);
   const [selectedSheet, setSelectedSheet] = useState(SheetTranslationKeys.Journal);
 
   const querySemester = searchParams.get('semester');


### PR DESCRIPTION
This pull request makes a minor update to the translation key used for tab labels in the Study Sheet module. The translation namespace for tabs is now correctly set to `private.study-sheet.tab`, which should resolve any issues with missing or incorrect tab translations.

- Updated the translation key from `private.study-sheet.sheet` to `private.study-sheet.tab` in the `InfoPageClient` component to ensure correct tab label translations. ([src/app/[locale]/(private)/module/studysheet/[id]/page.tsxL26-R26](diffhunk://#diff-9c730c42237a1f5682697db35927e77a75b54d9d045ffdc1d240ed1ff2017d1cL26-R26))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the translation key path for study sheet tab labels to ensure proper localization display across all supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->