### PR TITLE
KB‑837: Disable visibility of the student list for other students

### DIFF
--- a/src/app/[locale]/(private)/module/msg/components/compose.tsx
+++ b/src/app/[locale]/(private)/module/msg/components/compose.tsx
@@ -29,7 +29,7 @@ export default async function Compose({ profileArea }: Props) {
           </TabsList>
 
           <TabsContent value="individual" className="mt-6 space-y-6">
-            <Individual groupOptions={groupOptions} profileArea={profileArea} />
+            <Individual groupOptions={groupOptions} />
           </TabsContent>
 
           <TabsContent value="broadcast" className="mt-6">
@@ -38,7 +38,7 @@ export default async function Compose({ profileArea }: Props) {
         </Tabs>
       ) : (
         <div className="mt-6 space-y-6">
-          <Individual groupOptions={[]} profileArea={profileArea} />
+          <Individual groupOptions={[]} />
         </div>
       )}
     </div>

--- a/src/app/[locale]/(private)/module/msg/components/individual.tsx
+++ b/src/app/[locale]/(private)/module/msg/components/individual.tsx
@@ -18,16 +18,13 @@ import { useForm } from 'react-hook-form';
 import { useTranslations } from 'next-intl';
 import { useServerErrorToast } from '@/hooks/use-server-error-toast';
 import { Option, optionSchema } from '../types';
-import { ProfileArea } from '@/types/enums/profile-area';
 
 interface Props {
   groupOptions: EntityIdName[];
-  profileArea: ProfileArea;
 }
 
-export function Individual({ groupOptions, profileArea }: Props) {
-  const isEmployee = profileArea === ProfileArea.Employee;
-  // Students can only message employees, so default to 'employee' and only allow switching for employees
+export function Individual({ groupOptions }: Props) {
+  const hasGroupOptions = groupOptions.length > 0;
   const [recipientType, setRecipientType] = useState<'employee' | 'student'>('employee');
   const [userOptions, setUserOptions] = useState<EntityIdName[]>([]);
 
@@ -78,8 +75,7 @@ export function Individual({ groupOptions, profileArea }: Props) {
   }, [recipientType, form]);
 
   useEffect(() => {
-    // Only employees can select students as recipients
-    if (isEmployee && recipientType === 'student' && selectedGroups.length > 0) {
+    if (recipientType === 'student' && selectedGroups.length > 0) {
       const groupIds = selectedGroups.map((g) => Number(g.value));
       getStudentOptions(groupIds).then((students) => {
         setUserOptions(students);
@@ -87,7 +83,7 @@ export function Individual({ groupOptions, profileArea }: Props) {
     } else if (recipientType === 'student') {
       setUserOptions([]);
     }
-  }, [selectedGroups, recipientType, isEmployee]);
+  }, [selectedGroups, recipientType]);
 
   const handleEmployeeSearch = useCallback(async (value: string) => {
     if (value.length < 5) {
@@ -104,7 +100,7 @@ export function Individual({ groupOptions, profileArea }: Props) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-5 space-y-8">
-        {isEmployee && (
+        {hasGroupOptions && (
           <div className="flex gap-6">
             <RadioGroup
               className="flex"


### PR DESCRIPTION
This pull request updates the message composition functionality to ensure that only employees can send messages to students or broadcast to groups, while students are restricted to messaging employees. The UI and data-fetching logic have been refactored to enforce these permissions and prevent unauthorized API calls.

**Role-based restrictions and UI updates:**

* In `compose.tsx`, only employees can see and use the group broadcast tab and fetch group options; students no longer trigger group API calls and see only the individual message form. (`src/app/[locale]/(private)/module/msg/components/compose.tsx`) ([src/app/[locale]/(private)/module/msg/components/compose.tsxL14-R43](diffhunk://#diff-2635c273a312b549734af08f20f966cc2b1eb8b0fde9c0b8098b1fe5b2b94ce1L14-R43))
* In `individual.tsx`, the form now receives `profileArea` and determines if the user is an employee. Only employees can select the recipient type (employee or student); students default to messaging employees. (`src/app/[locale]/(private)/module/msg/components/individual.tsx`) ([src/app/[locale]/(private)/module/msg/components/individual.tsxR21-R30](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bR21-R30), [src/app/[locale]/(private)/module/msg/components/individual.tsxR103-R107](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bR103-R107), [src/app/[locale]/(private)/module/msg/components/individual.tsxR124](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bR124))

**Logic and data-fetching safeguards:**

* The effect that fetches student options for group messaging now runs only for employees, preventing students from making unauthorized API requests. (`src/app/[locale]/(private)/module/msg/components/individual.tsx`) ([src/app/[locale]/(private)/module/msg/components/individual.tsxL77-R90](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bL77-R90))

**Prop and code cleanups:**

* The `Individual` component now requires `profileArea` as a prop and passes it down from `compose.tsx`. (`src/app/[locale]/(private)/module/msg/components/compose.tsx`, `src/app/[locale]/(private)/module/msg/components/individual.tsx`) ([src/app/[locale]/(private)/module/msg/components/compose.tsxL14-R43](diffhunk://#diff-2635c273a312b549734af08f20f966cc2b1eb8b0fde9c0b8098b1fe5b2b94ce1L14-R43), [src/app/[locale]/(private)/module/msg/components/individual.tsxR21-R30](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bR21-R30))
* Minor formatting and code simplification in mapping user options. (`src/app/[locale]/(private)/module/msg/components/individual.tsx`) ([src/app/[locale]/(private)/module/msg/components/individual.tsxL156-R164](diffhunk://#diff-ac32821cec66ddf209effb201aa14882d1114ec40e05adddaa75b73232172a3bL156-R164))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Only employees now load group options and see the full tabbed compose interface; non-employees get a simplified compose view.
  * Recipient-type selection is hidden when no group options are available, preventing unavailable choices for non-employees.

* **UI Changes**
  * Employees see both "Individual" and "Broadcast" tabs; non-employees render the individual composer inline without tabs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->