### PR TITLE
Fix missing academic leave status

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -101,7 +101,8 @@
       },
       "student-status": {
         "dismissed": "Dismissed",
-        "studying": "Studying"
+        "studying": "Studying",
+        "on-academic-leave": "On Academic Leave"
       },
       "study-form": {
         "none": "Not specified",

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -101,7 +101,8 @@
       },
       "student-status": {
         "dismissed": "Відрахований",
-        "studying": "Навчається"
+        "studying": "Навчається",
+        "on-academic-leave": "В академічній відпустці"
       },
       "study-form": {
         "none": "Не вказано",

--- a/src/types/enums/student-status.ts
+++ b/src/types/enums/student-status.ts
@@ -1,4 +1,5 @@
 export enum StudentStatus {
   Dismissed = 'Dismissed',
   Studying = 'Studying',
+  OnAcademicLeave = 'OnAcademicLeave',
 }


### PR DESCRIPTION
This PR adds the missing `OnAcademicLeave` status to the student status enum and updates the localization files.

Fixes #742 