### PR TITLE
KB-1278 Add SBP rights server actions and TypeScript types

### DIFF
--- a/src/actions/sbp-rights.actions.ts
+++ b/src/actions/sbp-rights.actions.ts
@@ -100,9 +100,9 @@ export const getSbpRights = async (query: SbpRightsListQuery = {}): Promise<SbpR
     const params = new URLSearchParams();
     if (query.search) params.set('search', query.search);
     if (query.userAccountId) params.set('userAccountId', String(query.userAccountId));
-    if (query.sbpDcLoadId) params.set('sbpDcLoadId', String(query.sbpDcLoadId));
-    if (query.dcSubdivisionId) params.set('dcSubdivisionId', String(query.dcSubdivisionId));
-    if (query.dcStudingYearId) params.set('dcStudingYearId', String(query.dcStudingYearId));
+    if (query.loadId) params.set('loadId', String(query.loadId));
+    if (query.subdivisionId) params.set('subdivisionId', String(query.subdivisionId));
+    if (query.studyingYearId) params.set('studyingYearId', String(query.studyingYearId));
     if (query.page) params.set('page', String(query.page));
     if (query.pageSize) params.set('pageSize', String(query.pageSize));
 
@@ -124,12 +124,16 @@ export const getSbpRights = async (query: SbpRightsListQuery = {}): Promise<SbpR
 };
 
 export const grantSbpRights = async (payload: GrantSbpRightsPayload): Promise<GrantSbpRightsResult> => {
+  if (payload.scope === 'Faculty' && !payload.subdivisionId) {
+    throw new Error("subdivisionId is required when scope is 'Faculty'");
+  }
+
   const body = JSON.stringify({
     userAccountId: payload.userAccountId,
     scope: payload.scope,
-    dcSubdivisionId: payload.scope === 'University' ? undefined : payload.dcSubdivisionId,
-    dcStudingYearId: payload.dcStudingYearId,
-    sbpDcLoadIds: payload.sbpDcLoadIds,
+    subdivisionId: payload.scope === 'University' ? undefined : payload.subdivisionId,
+    studyingYearId: payload.studyingYearId,
+    loadIds: payload.loadIds,
   });
 
   const response = await campusFetch('sbp-rights', { method: 'POST', body });

--- a/src/actions/sbp-rights.actions.ts
+++ b/src/actions/sbp-rights.actions.ts
@@ -1,0 +1,154 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { campusFetch } from '@/lib/client';
+import { EntityIdName } from '@/types/models/entity-id-name';
+import {
+  GrantSbpRightsPayload,
+  GrantSbpRightsResult,
+  SbpLoadCatalogItem,
+  SbpResponsibilityListItem,
+  SbpRightsListQuery,
+  SbpStudyYearCatalogItem,
+  SbpSubdivisionCatalogItem,
+} from '@/types/models/sbp-rights';
+
+const MODULE_PATH = '/module/studbonuspointsrights';
+
+/**
+ * Whether the current user is a SuperAdmin allowed to access the SBP rights
+ * admin module. Public endpoint (no `RequireSbpRightsAdmin` guard) so the FE
+ * can use the result to decide whether to render the menu entry.
+ */
+export const getSbpRightsMe = async (): Promise<{ isSuperAdmin: boolean }> => {
+  try {
+    const response = await campusFetch<{ isSuperAdmin: boolean }>('sbp-rights/me');
+    if (!response.ok) {
+      return { isSuperAdmin: false };
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching SBP rights identity:', error);
+    return { isSuperAdmin: false };
+  }
+};
+
+export const getSbpLoads = async (): Promise<SbpLoadCatalogItem[]> => {
+  try {
+    const response = await campusFetch<SbpLoadCatalogItem[]>('sbp-rights/loads');
+    if (!response.ok) {
+      return [];
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching SBP loads:', error);
+    return [];
+  }
+};
+
+export const getSbpSubdivisions = async (): Promise<SbpSubdivisionCatalogItem[]> => {
+  try {
+    const response = await campusFetch<SbpSubdivisionCatalogItem[]>('sbp-rights/subdivisions');
+    if (!response.ok) {
+      return [];
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching SBP subdivisions:', error);
+    return [];
+  }
+};
+
+export const getSbpStudyYears = async (): Promise<SbpStudyYearCatalogItem[]> => {
+  try {
+    const response = await campusFetch<SbpStudyYearCatalogItem[]>('sbp-rights/study-years');
+    if (!response.ok) {
+      return [];
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching SBP study years:', error);
+    return [];
+  }
+};
+
+export const searchSbpUsers = async (query: string): Promise<EntityIdName[]> => {
+  try {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      return [];
+    }
+    const params = new URLSearchParams({ q: trimmed });
+    const response = await campusFetch<EntityIdName[]>(`sbp-rights/users/search?${params.toString()}`);
+    if (!response.ok) {
+      return [];
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error searching SBP users:', error);
+    return [];
+  }
+};
+
+export interface SbpRightsResult {
+  items: SbpResponsibilityListItem[];
+  total: number;
+}
+
+export const getSbpRights = async (query: SbpRightsListQuery = {}): Promise<SbpRightsResult> => {
+  try {
+    const params = new URLSearchParams();
+    if (query.search) params.set('search', query.search);
+    if (query.userAccountId) params.set('userAccountId', String(query.userAccountId));
+    if (query.sbpDcLoadId) params.set('sbpDcLoadId', String(query.sbpDcLoadId));
+    if (query.dcSubdivisionId) params.set('dcSubdivisionId', String(query.dcSubdivisionId));
+    if (query.dcStudingYearId) params.set('dcStudingYearId', String(query.dcStudingYearId));
+    if (query.page) params.set('page', String(query.page));
+    if (query.pageSize) params.set('pageSize', String(query.pageSize));
+
+    const qs = params.toString();
+    const url = qs ? `sbp-rights?${qs}` : 'sbp-rights';
+    const response = await campusFetch<SbpResponsibilityListItem[]>(url);
+
+    if (!response.ok) {
+      return { items: [], total: 0 };
+    }
+
+    const items = (await response.json()) as SbpResponsibilityListItem[];
+    const total = parseInt(response.headers.get('x-total-count') ?? '0', 10) || 0;
+    return { items, total };
+  } catch (error) {
+    console.error('Error fetching SBP rights:', error);
+    return { items: [], total: 0 };
+  }
+};
+
+export const grantSbpRights = async (payload: GrantSbpRightsPayload): Promise<GrantSbpRightsResult> => {
+  const body = JSON.stringify({
+    userAccountId: payload.userAccountId,
+    scope: payload.scope,
+    dcSubdivisionId: payload.scope === 'University' ? undefined : payload.dcSubdivisionId,
+    dcStudingYearId: payload.dcStudingYearId,
+    sbpDcLoadIds: payload.sbpDcLoadIds,
+  });
+
+  const response = await campusFetch('sbp-rights', { method: 'POST', body });
+
+  if (!response.ok) {
+    throw new Error(`Failed to grant SBP rights: ${response.status} ${response.statusText}`);
+  }
+
+  const result = (await response.json()) as GrantSbpRightsResult;
+  revalidatePath(MODULE_PATH);
+  return result;
+};
+
+export const revokeSbpRight = async (sbpResponsibleId: number): Promise<void> => {
+  const response = await campusFetch(`sbp-rights/${sbpResponsibleId}`, { method: 'DELETE' });
+
+  if (!response.ok) {
+    throw new Error(`Failed to revoke SBP right: ${response.status} ${response.statusText}`);
+  }
+
+  revalidatePath(MODULE_PATH);
+};

--- a/src/types/models/sbp-rights.ts
+++ b/src/types/models/sbp-rights.ts
@@ -1,0 +1,81 @@
+import { EntityIdName } from './entity-id-name';
+
+/**
+ * Scope of an SBP rights grant. Mirrors `KPI.Domain.Base.AccessScope`
+ * (serialized as a string thanks to `JsonStringEnumConverter`).
+ */
+export type AccessScope = 'Faculty' | 'University';
+
+export interface SbpLoadCatalogItem {
+  workKindId: number;
+  workKindName: string;
+  treeId: number;
+  treeName: string;
+  loadId: number;
+  loadName: string;
+  /** SubTreeNumber on the load row, used for display ordering. */
+  subTreeNumber: number | null;
+  mark: number;
+}
+
+export interface SbpSubdivisionCatalogItem {
+  id: number;
+  name: string;
+  abbreviation: string | null;
+  isUniversityWide: boolean;
+}
+
+export interface SbpStudyYearCatalogItem {
+  id: number;
+  name: string;
+  isCurrent: boolean;
+}
+
+/** User search result for the grant autocomplete — reuses the shared `EntityIdName`. */
+export type SbpUserPick = EntityIdName;
+
+/** Denormalized row returned by `GET /sbp-rights`. */
+export interface SbpResponsibilityListItem {
+  id: number;
+  userAccountId: number;
+  fullName: string;
+  scope: AccessScope;
+  subdivisionId: number;
+  subdivisionName: string;
+  subdivisionAbbreviation: string | null;
+  studyingYearId: number;
+  studyingYearName: string;
+  loadId: number;
+  loadName: string;
+  loadSubTreeNumber: number | null;
+  treeName: string;
+  workKindName: string;
+  changeDate: string;
+  comment: string | null;
+}
+
+export interface SbpRightsListQuery {
+  search?: string;
+  userAccountId?: number;
+  sbpDcLoadId?: number;
+  dcSubdivisionId?: number;
+  dcStudingYearId?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface GrantSbpRightsPayload {
+  userAccountId: number;
+  scope: AccessScope;
+  /** Required when `scope === 'Faculty'`; ignored otherwise. */
+  dcSubdivisionId?: number;
+  /** When omitted, the backend resolves the current study year. */
+  dcStudingYearId?: number;
+  sbpDcLoadIds: number[];
+}
+
+export interface GrantSbpRightsResult {
+  createdIds: number[];
+  /** Loads that already had an active grant — no new row was created for them. */
+  skippedDuplicates: number[];
+}

--- a/src/types/models/sbp-rights.ts
+++ b/src/types/models/sbp-rights.ts
@@ -57,9 +57,9 @@ export interface SbpResponsibilityListItem {
 export interface SbpRightsListQuery {
   search?: string;
   userAccountId?: number;
-  sbpDcLoadId?: number;
-  dcSubdivisionId?: number;
-  dcStudingYearId?: number;
+  loadId?: number;
+  subdivisionId?: number;
+  studyingYearId?: number;
   page?: number;
   pageSize?: number;
 }
@@ -68,10 +68,10 @@ export interface GrantSbpRightsPayload {
   userAccountId: number;
   scope: AccessScope;
   /** Required when `scope === 'Faculty'`; ignored otherwise. */
-  dcSubdivisionId?: number;
+  subdivisionId?: number;
   /** When omitted, the backend resolves the current study year. */
-  dcStudingYearId?: number;
-  sbpDcLoadIds: number[];
+  studyingYearId?: number;
+  loadIds: number[];
 }
 
 export interface GrantSbpRightsResult {


### PR DESCRIPTION
Two files:

- src/types/models/sbp-rights.ts — TS types mirroring the BE contracts: AccessScope (union), the catalog items, list item, query/payload/result shapes. SbpUserPick is just an alias for the existing EntityIdName ({ id, name }) so the user search reuses the shared FE primitive instead of inventing a new type.

- src/actions/sbp-rights.actions.ts — eight server actions wrapping the /sbp-rights endpoints. Style mirrors announcement.actions.ts: catalog reads swallow errors and return empty arrays; mutations (grant, revoke) throw on failure so the calling component can surface a toast. grantSbpRights drops dcSubdivisionId on the wire when scope === 'University'. Both mutations call revalidatePath for the rights module so the list re-renders after.

Total list (X-Total-Count header) is parsed off the response, matching how the announcement admin list handles paging.

Page, dialog, and revoke UX land in KB-1279/KB-1280/KB-1281.