### PR TITLE
KB-1280 Add Grant rights dialog

### DIFF
--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-button.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-button.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  SbpLoadCatalogItem,
+  SbpStudyYearCatalogItem,
+  SbpSubdivisionCatalogItem,
+} from '@/types/models/sbp-rights';
+import { GrantRightsDialog } from './grant-rights-dialog';
+
+interface Props {
+  loads: SbpLoadCatalogItem[];
+  subdivisions: SbpSubdivisionCatalogItem[];
+  years: SbpStudyYearCatalogItem[];
+}
+
+/**
+ * Header button that opens the Grant Rights dialog. Holds the open state
+ * locally so the page (a server component) doesn't need to.
+ */
+export function GrantButton({ loads, subdivisions, years }: Props) {
+  const t = useTranslations('private.studbonuspointsrights.grant');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} className="flex items-center gap-2">
+        <Plus className="h-4 w-4" />
+        {t('button')}
+      </Button>
+      <GrantRightsDialog
+        open={open}
+        onOpenChange={setOpen}
+        loads={loads}
+        subdivisions={subdivisions}
+        years={years}
+      />
+    </>
+  );
+}

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-rights-dialog.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-rights-dialog.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { useServerErrorToast } from '@/hooks/use-server-error-toast';
+import { grantSbpRights } from '@/actions/sbp-rights.actions';
+import {
+  AccessScope,
+  SbpLoadCatalogItem,
+  SbpStudyYearCatalogItem,
+  SbpSubdivisionCatalogItem,
+} from '@/types/models/sbp-rights';
+import { GrantRightsFormValues, grantRightsSchema } from './grant-rights-schema';
+import { LoadMultiSelect } from './load-multi-select';
+import { UserAutocomplete } from './user-autocomplete';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  loads: SbpLoadCatalogItem[];
+  subdivisions: SbpSubdivisionCatalogItem[];
+  years: SbpStudyYearCatalogItem[];
+}
+
+export function GrantRightsDialog({ open, onOpenChange, loads, subdivisions, years }: Props) {
+  const t = useTranslations('private.studbonuspointsrights.grant');
+  const { toast } = useToast();
+  const { errorToast } = useServerErrorToast();
+
+  const facultyOptions = useMemo(
+    () => subdivisions.filter((s) => !s.isUniversityWide),
+    [subdivisions],
+  );
+  const currentYear = useMemo(() => years.find((y) => y.isCurrent) ?? years[0], [years]);
+
+  const form = useForm<GrantRightsFormValues>({
+    resolver: zodResolver(grantRightsSchema),
+    defaultValues: {
+      userAccountId: 0,
+      scope: 'Faculty',
+      subdivisionId: undefined,
+      studyingYearId: currentYear?.id ?? 0,
+      loadIds: [],
+    },
+    mode: 'onChange',
+  });
+
+  // Reset the form whenever the dialog opens so a previous draft doesn't
+  // bleed into the next session.
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        userAccountId: 0,
+        scope: 'Faculty',
+        subdivisionId: undefined,
+        studyingYearId: currentYear?.id ?? 0,
+        loadIds: [],
+      });
+    }
+  }, [open, currentYear?.id, form]);
+
+  const scope = form.watch('scope');
+
+  const onSubmit = async (values: GrantRightsFormValues) => {
+    try {
+      const result = await grantSbpRights({
+        userAccountId: values.userAccountId,
+        scope: values.scope,
+        subdivisionId: values.scope === 'University' ? undefined : values.subdivisionId,
+        studyingYearId: values.studyingYearId,
+        loadIds: values.loadIds,
+      });
+      toast({
+        title: t('success.title'),
+        description: t('success.description', {
+          granted: result.createdIds.length,
+          skipped: result.skippedDuplicates.length,
+        }),
+      });
+      onOpenChange(false);
+    } catch {
+      errorToast();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{t('description')}</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="userAccountId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{t('user')}</FormLabel>
+                  <FormControl>
+                    <UserAutocomplete
+                      value={field.value || undefined}
+                      onChange={(id) => field.onChange(id)}
+                    />
+                  </FormControl>
+                  {fieldState.error && <FormMessage>{t(fieldState.error.message ?? '')}</FormMessage>}
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="scope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('scope')}</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      value={field.value}
+                      onValueChange={(v) => field.onChange(v as AccessScope)}
+                      className="flex gap-4"
+                    >
+                      <label className="flex items-center gap-2">
+                        <RadioGroupItem value="Faculty" />
+                        {t('scopeFaculty')}
+                      </label>
+                      <label className="flex items-center gap-2">
+                        <RadioGroupItem value="University" />
+                        {t('scopeUniversity')}
+                      </label>
+                    </RadioGroup>
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            {scope === 'Faculty' && (
+              <FormField
+                control={form.control}
+                name="subdivisionId"
+                render={({ field, fieldState }) => (
+                  <FormItem>
+                    <FormLabel>{t('subdivision')}</FormLabel>
+                    <Select
+                      value={field.value ? String(field.value) : ''}
+                      onValueChange={(v) => field.onChange(Number(v))}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder={t('subdivisionPlaceholder')} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {facultyOptions.map((s) => (
+                          <SelectItem key={s.id} value={String(s.id)}>
+                            {s.abbreviation ?? s.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {fieldState.error && <FormMessage>{t(fieldState.error.message ?? '')}</FormMessage>}
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="studyingYearId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{t('year')}</FormLabel>
+                  <Select
+                    value={field.value ? String(field.value) : ''}
+                    onValueChange={(v) => field.onChange(Number(v))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t('yearPlaceholder')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {years.map((y) => (
+                        <SelectItem key={y.id} value={String(y.id)}>
+                          {y.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldState.error && <FormMessage>{t(fieldState.error.message ?? '')}</FormMessage>}
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="loadIds"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>{t('loads')}</FormLabel>
+                  <FormControl>
+                    <LoadMultiSelect loads={loads} value={field.value} onChange={field.onChange} />
+                  </FormControl>
+                  {fieldState.error && <FormMessage>{t(fieldState.error.message ?? '')}</FormMessage>}
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+                {t('cancel')}
+              </Button>
+              <Button type="submit" variant="primary" disabled={form.formState.isSubmitting}>
+                {t('submit')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-rights-schema.ts
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/grant-rights-schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Form schema for the Grant Rights dialog. The flat shape stays friendly to
+ * react-hook-form `defaultValues`; the refine clause enforces that
+ * `subdivisionId` is supplied for Faculty scope. The grant action also
+ * runs the same check at the wire boundary.
+ */
+export const grantRightsSchema = z
+  .object({
+    userAccountId: z.number().int().positive('grant.errors.userRequired'),
+    scope: z.enum(['Faculty', 'University']),
+    subdivisionId: z.number().int().positive().optional(),
+    studyingYearId: z.number().int().positive('grant.errors.yearRequired'),
+    loadIds: z.array(z.number().int().positive()).min(1, 'grant.errors.loadsRequired'),
+  })
+  .refine((d) => d.scope === 'University' || (d.subdivisionId != null && d.subdivisionId > 0), {
+    message: 'grant.errors.subdivisionRequired',
+    path: ['subdivisionId'],
+  });
+
+export type GrantRightsFormValues = z.infer<typeof grantRightsSchema>;

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { SbpLoadCatalogItem } from '@/types/models/sbp-rights';
+
+interface Props {
+  loads: SbpLoadCatalogItem[];
+  value: number[];
+  onChange: (next: number[]) => void;
+}
+
+interface Group {
+  workKindId: number;
+  workKindName: string;
+  treeId: number;
+  treeName: string;
+  loads: SbpLoadCatalogItem[];
+}
+
+/**
+ * Multi-select for SBP loads, grouped by work-kind → tree. Selection is held
+ * in the parent form (array of loadIds). Toggling a row updates the array;
+ * the popover stays open so the SuperAdmin can pick several loads in a row.
+ */
+export function LoadMultiSelect({ loads, value, onChange }: Props) {
+  const t = useTranslations('private.studbonuspointsrights.grant');
+  const [open, setOpen] = useState(false);
+
+  const groups = useMemo<Group[]>(() => {
+    const map = new Map<string, Group>();
+    for (const load of loads) {
+      const key = `${load.workKindId}:${load.treeId}`;
+      let group = map.get(key);
+      if (!group) {
+        group = {
+          workKindId: load.workKindId,
+          workKindName: load.workKindName,
+          treeId: load.treeId,
+          treeName: load.treeName,
+          loads: [],
+        };
+        map.set(key, group);
+      }
+      group.loads.push(load);
+    }
+    return [...map.values()];
+  }, [loads]);
+
+  const selected = new Set(value);
+
+  const toggle = (loadId: number) => {
+    const next = selected.has(loadId)
+      ? value.filter((id) => id !== loadId)
+      : [...value, loadId];
+    onChange(next);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn(value.length === 0 && 'text-muted-foreground')}>
+            {value.length === 0 ? t('loadsPlaceholder') : t('loadsSelected', { count: value.length })}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder={t('loadsSearchPlaceholder')} />
+          <CommandList className="max-h-72">
+            <CommandEmpty>{t('loadsNotFound')}</CommandEmpty>
+            {groups.map((group) => (
+              <CommandGroup
+                key={`${group.workKindId}:${group.treeId}`}
+                heading={`${group.workKindName} · ${group.treeName}`}
+              >
+                {group.loads.map((load) => {
+                  const isSelected = selected.has(load.loadId);
+                  return (
+                    <CommandItem
+                      key={load.loadId}
+                      value={`${load.subTreeNumber ?? ''} ${load.loadName}`}
+                      onSelect={() => toggle(load.loadId)}
+                    >
+                      <Check className={cn('mr-2 h-4 w-4', isSelected ? 'opacity-100' : 'opacity-0')} />
+                      <span className="flex-1">
+                        {load.subTreeNumber != null ? `${load.subTreeNumber}. ` : ''}
+                        {load.loadName}
+                      </span>
+                      <span className="text-muted-foreground ml-2 text-xs">{load.mark}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/user-autocomplete.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/user-autocomplete.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useDebounce } from '@/components/ui/multi-select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { searchSbpUsers } from '@/actions/sbp-rights.actions';
+import { cn } from '@/lib/utils';
+import { EntityIdName } from '@/types/models/entity-id-name';
+
+interface Props {
+  value: number | undefined;
+  onChange: (userAccountId: number, fullName: string) => void;
+}
+
+/**
+ * Combobox + Command that searches users by full name (≥ 2 chars, debounced).
+ * Selecting a user calls `onChange(userAccountId, fullName)` so the parent
+ * form can both store the id and display the chosen name.
+ */
+export function UserAutocomplete({ value, onChange }: Props) {
+  const t = useTranslations('private.studbonuspointsrights.grant');
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedLabel, setSelectedLabel] = useState<string>('');
+  const [results, setResults] = useState<EntityIdName[]>([]);
+  const debouncedQuery = useDebounce(query, 300);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (debouncedQuery.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    void searchSbpUsers(debouncedQuery).then((rows) => {
+      if (!cancelled) setResults(rows);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn(!selectedLabel && 'text-muted-foreground')}>
+            {selectedLabel || t('userPlaceholder')}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder={t('userSearchPlaceholder')} value={query} onValueChange={setQuery} />
+          <CommandList>
+            <CommandEmpty>{t(query.trim().length < 2 ? 'userMinChars' : 'userNotFound')}</CommandEmpty>
+            {results.map((user) => (
+              <CommandItem
+                key={user.id}
+                value={String(user.id)}
+                onSelect={() => {
+                  onChange(user.id, user.name);
+                  setSelectedLabel(user.name);
+                  setOpen(false);
+                }}
+              >
+                <Check className={cn('mr-2 h-4 w-4', value === user.id ? 'opacity-100' : 'opacity-0')} />
+                {user.name}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/page.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/page.tsx
@@ -9,6 +9,7 @@ import {
   getSbpSubdivisions,
 } from '@/actions/sbp-rights.actions';
 import { LocaleProps } from '@/types/locale-props';
+import { GrantButton } from './components/grant-button';
 import { RightsEmptyState } from './components/rights-empty-state';
 import { RightsFilters } from './components/rights-filters';
 import { RightsTable } from './components/rights-table';
@@ -62,9 +63,12 @@ export default async function SbpRightsPage({ searchParams }: PageProps) {
   return (
     <SubLayout pageTitle={t('title')}>
       <div className="col-span-12 space-y-6">
-        <div>
-          <Heading2>{t('title')}</Heading2>
-          <Description>{t('subtitle')}</Description>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Heading2>{t('title')}</Heading2>
+            <Description>{t('subtitle')}</Description>
+          </div>
+          <GrantButton loads={loads} subdivisions={subdivisions} years={years} />
         </div>
 
         <RightsFilters

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -480,6 +480,40 @@
           "title": "Nothing matches",
           "subtitle": "Try adjusting the filters or clearing the search."
         }
+      },
+      "grant": {
+        "button": "Grant rights",
+        "title": "Grant rights",
+        "description": "Pick a user, scope, and the points this user will administer.",
+        "user": "User",
+        "userPlaceholder": "Pick a user",
+        "userSearchPlaceholder": "Start typing a name",
+        "userMinChars": "Type at least 2 characters.",
+        "userNotFound": "No user found.",
+        "scope": "Scope",
+        "scopeFaculty": "Faculty",
+        "scopeUniversity": "University",
+        "subdivision": "Subdivision",
+        "subdivisionPlaceholder": "Pick a faculty",
+        "year": "Study year",
+        "yearPlaceholder": "Pick a year",
+        "loads": "Points",
+        "loadsPlaceholder": "Pick points",
+        "loadsSelected": "{count} selected",
+        "loadsSearchPlaceholder": "Search a point",
+        "loadsNotFound": "No point found.",
+        "submit": "Grant",
+        "cancel": "Cancel",
+        "errors": {
+          "userRequired": "Pick a user.",
+          "yearRequired": "Pick a study year.",
+          "loadsRequired": "Pick at least one point.",
+          "subdivisionRequired": "Pick a faculty."
+        },
+        "success": {
+          "title": "Done",
+          "description": "Granted {granted}, skipped {skipped} duplicates."
+        }
       }
     },
     "profile": {

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -480,6 +480,40 @@
           "title": "Нічого не знайдено",
           "subtitle": "Спробуйте змінити фільтри або очистити пошук."
         }
+      },
+      "grant": {
+        "button": "Видати право",
+        "title": "Видача прав",
+        "description": "Виберіть користувача, рівень і пункти, на які цей користувач буде мати права адміністрування.",
+        "user": "Користувач",
+        "userPlaceholder": "Виберіть користувача",
+        "userSearchPlaceholder": "Почніть вводити ПІБ",
+        "userMinChars": "Введіть щонайменше 2 символи.",
+        "userNotFound": "Користувача не знайдено.",
+        "scope": "Рівень",
+        "scopeFaculty": "Факультет",
+        "scopeUniversity": "Університет",
+        "subdivision": "Підрозділ",
+        "subdivisionPlaceholder": "Виберіть факультет",
+        "year": "Навчальний рік",
+        "yearPlaceholder": "Виберіть рік",
+        "loads": "Пункти",
+        "loadsPlaceholder": "Виберіть пункти",
+        "loadsSelected": "Обрано пунктів: {count}",
+        "loadsSearchPlaceholder": "Пошук пункту",
+        "loadsNotFound": "Пункти не знайдено.",
+        "submit": "Видати",
+        "cancel": "Скасувати",
+        "errors": {
+          "userRequired": "Виберіть користувача.",
+          "yearRequired": "Виберіть навчальний рік.",
+          "loadsRequired": "Виберіть щонайменше один пункт.",
+          "subdivisionRequired": "Виберіть факультет."
+        },
+        "success": {
+          "title": "Готово",
+          "description": "Видано: {granted}, пропущено дублікатів: {skipped}."
+        }
       }
     },
     "profile": {


### PR DESCRIPTION
Five new components + page wiring:

- grant-rights-schema.ts: zod schema with refine() that requires subdivisionId for Faculty scope. Error messages are i18n keys resolved by the dialog when rendering FormMessage.
- user-autocomplete.tsx: shadcn Command in a Popover. Calls searchSbpUsers (≥ 2 chars, debounced 300ms via the existing useDebounce hook). Stores both the userAccountId and the display name so the trigger shows the chosen name.
- load-multi-select.tsx: Command grouped by work-kind → tree. Each item shows "subTreeNumber. name" + the mark on the right. Toggling keeps the popover open so the SuperAdmin can pick several loads in a row.
- grant-rights-dialog.tsx: shadcn Dialog wrapping a react-hook-form with zodResolver. Subdivision Select renders only for Faculty scope. Year defaults to the current year. On submit the action is called and a toast shows "Granted N, skipped M duplicates"; errors surface via the existing useServerErrorToast.
- grant-button.tsx: header button + dialog open state. Holds the state locally so the page (server component) doesn't need to.

page.tsx now renders <GrantButton> next to the heading, completing the FE-3 deferred piece. revalidatePath in grantSbpRights refreshes the list automatically.

i18n: extended private.studbonuspointsrights.grant in uk + en with button/labels/placeholders/errors/success copy. Variant tweaks for this codebase: shadcn-style "outline" buttons → secondary.