### PR TITLE
KB-1281 Add per-row Revoke action

### DIFF
--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/revoke-button.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/revoke-button.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Trash2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { revokeSbpRight } from '@/actions/sbp-rights.actions';
+import { useToast } from '@/hooks/use-toast';
+import { useServerErrorToast } from '@/hooks/use-server-error-toast';
+import { SbpResponsibilityListItem } from '@/types/models/sbp-rights';
+
+interface Props {
+  item: SbpResponsibilityListItem;
+}
+
+/**
+ * Per-row revoke action. Wraps a destructive AlertDialog around a small
+ * trash-icon button. Confirmation copy includes the user, point and
+ * subdivision so the SuperAdmin can sanity-check the target before clicking
+ * through.
+ */
+export function RevokeButton({ item }: Props) {
+  const t = useTranslations('private.studbonuspointsrights.revoke');
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+  const { errorToast } = useServerErrorToast();
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      try {
+        await revokeSbpRight(item.id);
+        toast({ title: t('success.title'), description: t('success.description') });
+        setOpen(false);
+      } catch {
+        errorToast();
+      }
+    });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="tertiary"
+          size="small"
+          aria-label={t('trigger')}
+          className="text-status-danger-300 hover:text-red-700"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('description', {
+              user: item.fullName,
+              load: item.loadName,
+              subdivision: item.subdivisionAbbreviation ?? item.subdivisionName,
+              year: item.studyingYearName,
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isPending}
+            className="bg-status-danger-300 hover:bg-red-600 active:border-red-700 active:bg-red-700"
+          >
+            {t('confirm')}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
@@ -5,15 +5,12 @@ import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { formatDate } from '@/lib/utils';
 import { SbpResponsibilityListItem } from '@/types/models/sbp-rights';
+import { RevokeButton } from './revoke-button';
 
 interface Props {
   items: SbpResponsibilityListItem[];
 }
 
-/**
- * Read-only listing of granted SBP rights. Per-row Revoke action lands in
- * KB-1281 (FE-5).
- */
 export function RightsTable({ items }: Props) {
   const t = useTranslations('private.studbonuspointsrights');
 
@@ -27,6 +24,9 @@ export function RightsTable({ items }: Props) {
           <TableHead>{t('table.year')}</TableHead>
           <TableHead>{t('table.load')}</TableHead>
           <TableHead>{t('table.created')}</TableHead>
+          <TableHead className="w-12 text-right">
+            <span className="sr-only">{t('table.actions')}</span>
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -52,6 +52,9 @@ export function RightsTable({ items }: Props) {
               </div>
             </TableCell>
             <TableCell className="whitespace-nowrap">{formatDate(item.changeDate)}</TableCell>
+            <TableCell className="text-right">
+              <RevokeButton item={item} />
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -459,7 +459,8 @@
         "subdivision": "Subdivision",
         "year": "Year",
         "load": "Point",
-        "created": "Granted"
+        "created": "Granted",
+        "actions": "Actions"
       },
       "filters": {
         "searchPlaceholder": "Search by full name",
@@ -513,6 +514,17 @@
         "success": {
           "title": "Done",
           "description": "Granted {granted}, skipped {skipped} duplicates."
+        }
+      },
+      "revoke": {
+        "trigger": "Revoke right",
+        "title": "Revoke this right?",
+        "description": "{user} will lose admin access to \"{load}\" for {subdivision} ({year}).",
+        "confirm": "Revoke",
+        "cancel": "Cancel",
+        "success": {
+          "title": "Done",
+          "description": "Right revoked."
         }
       }
     },

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -459,7 +459,8 @@
         "subdivision": "Підрозділ",
         "year": "Рік",
         "load": "Пункт",
-        "created": "Видано"
+        "created": "Видано",
+        "actions": "Дії"
       },
       "filters": {
         "searchPlaceholder": "Пошук за ПІБ",
@@ -513,6 +514,17 @@
         "success": {
           "title": "Готово",
           "description": "Видано: {granted}, пропущено дублікатів: {skipped}."
+        }
+      },
+      "revoke": {
+        "trigger": "Відкликати право",
+        "title": "Відкликати право?",
+        "description": "{user} втратить право адмініструвати пункт «{load}» для {subdivision} ({year}).",
+        "confirm": "Відкликати",
+        "cancel": "Скасувати",
+        "success": {
+          "title": "Готово",
+          "description": "Право відкликано."
         }
       }
     },


### PR DESCRIPTION
Two pieces:

- New revoke-button.tsx wraps a destructive AlertDialog around a trash-icon trigger. The dialog body includes the user, point, subdivision and year so the SuperAdmin can sanity-check the target before confirming. Confirm fires revokeSbpRight in a useTransition; success uses the standard toast hook, failure falls back to useServerErrorToast. revalidatePath in the action refreshes the list automatically.

- rights-table.tsx grows an Actions column at the right edge, rendering <RevokeButton item={item} /> per row.

i18n: extended private.studbonuspointsrights with revoke.* in both uk.json and en.json, plus table.actions for the new column header (sr-only — visually empty, screen-reader-friendly).

Destructive button styling reuses the same Tailwind classes already used by facultycertificate's reject-dialog (bg-status-danger-300 + red hover/active) — this codebase doesn't have a "destructive" Button variant.