### PR TITLE
KB-1307 Add Select-all on grant; group review rows by year/name/subdivision

### DIFF
--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
@@ -2,6 +2,7 @@
 
 import { useId, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { SbpLoadCatalogItem } from '@/types/models/sbp-rights';
 
@@ -21,7 +22,8 @@ interface Group {
 
 /**
  * Flat checkbox list of SBP loads, grouped by work-kind → tree. Selection
- * is held in the parent form (array of loadIds).
+ * is held in the parent form (array of loadIds). A global and per-group
+ * Select-all / Clear toggle (KB-1307) avoids hand-checking long lists.
  */
 export function LoadMultiSelect({ loads, value, onChange }: Props) {
   const t = useTranslations('private.studbonuspointsrights.grant');
@@ -53,43 +55,94 @@ export function LoadMultiSelect({ loads, value, onChange }: Props) {
     onChange(selected.has(loadId) ? value.filter((id) => id !== loadId) : [...value, loadId]);
   };
 
+  const allLoadIds = useMemo(() => loads.map((l) => l.loadId), [loads]);
+  const allSelected = allLoadIds.length > 0 && allLoadIds.every((id) => selected.has(id));
+
+  const toggleAll = () => {
+    onChange(allSelected ? [] : allLoadIds);
+  };
+
+  const toggleGroup = (group: Group) => {
+    const groupIds = group.loads.map((l) => l.loadId);
+    const allInGroup = groupIds.every((id) => selected.has(id));
+    if (allInGroup) {
+      const groupSet = new Set(groupIds);
+      onChange(value.filter((id) => !groupSet.has(id)));
+    } else {
+      const merged = new Set(value);
+      for (const id of groupIds) merged.add(id);
+      onChange([...merged]);
+    }
+  };
+
   if (groups.length === 0) {
     return <p className="text-muted-foreground text-sm">{t('loadsNotFound')}</p>;
   }
 
   return (
-    <div className="max-h-96 space-y-4 overflow-y-auto rounded-md border p-3">
-      {groups.map((group) => (
-        <div key={`${group.workKindId}:${group.treeId}`}>
-          <div className="text-muted-foreground mb-2 text-xs font-semibold uppercase tracking-wide">
-            {group.workKindName} · {group.treeName}
-          </div>
-          <div className="flex flex-col gap-2">
-            {group.loads.map((load) => {
-              const id = `${idPrefix}-${load.loadId}`;
-              return (
-                <label
-                  key={load.loadId}
-                  htmlFor={id}
-                  className="flex cursor-pointer items-start gap-2 text-sm"
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground text-xs">
+          {t('loadsSelected', { count: value.length })}
+        </span>
+        <Button
+          type="button"
+          variant="tertiary"
+          size="small"
+          onClick={toggleAll}
+          className="h-7 px-2 text-xs"
+        >
+          {allSelected ? t('clearAll') : t('selectAll')}
+        </Button>
+      </div>
+      <div className="max-h-96 space-y-4 overflow-y-auto rounded-md border p-3">
+        {groups.map((group) => {
+          const groupIds = group.loads.map((l) => l.loadId);
+          const allInGroup = groupIds.every((id) => selected.has(id));
+          return (
+            <div key={`${group.workKindId}:${group.treeId}`}>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+                  {group.workKindName} · {group.treeName}
+                </div>
+                <Button
+                  type="button"
+                  variant="tertiary"
+                  size="small"
+                  onClick={() => toggleGroup(group)}
+                  className="h-6 px-2 text-xs"
                 >
-                  <Checkbox
-                    id={id}
-                    checked={selected.has(load.loadId)}
-                    onCheckedChange={() => toggle(load.loadId)}
-                    className="mt-0.5"
-                  />
-                  <span className="flex-1">
-                    {load.subTreeNumber != null ? `${load.subTreeNumber}. ` : ''}
-                    {load.loadName}
-                  </span>
-                  <span className="text-muted-foreground text-xs">{load.mark}</span>
-                </label>
-              );
-            })}
-          </div>
-        </div>
-      ))}
+                  {allInGroup ? t('clearAll') : t('selectAll')}
+                </Button>
+              </div>
+              <div className="flex flex-col gap-2">
+                {group.loads.map((load) => {
+                  const id = `${idPrefix}-${load.loadId}`;
+                  return (
+                    <label
+                      key={load.loadId}
+                      htmlFor={id}
+                      className="flex cursor-pointer items-start gap-2 text-sm"
+                    >
+                      <Checkbox
+                        id={id}
+                        checked={selected.has(load.loadId)}
+                        onCheckedChange={() => toggle(load.loadId)}
+                        className="mt-0.5"
+                      />
+                      <span className="flex-1">
+                        {load.subTreeNumber != null ? `${load.subTreeNumber}. ` : ''}
+                        {load.loadName}
+                      </span>
+                      <span className="text-muted-foreground text-xs">{load.mark}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/load-multi-select.tsx
@@ -90,7 +90,7 @@ export function LoadMultiSelect({ loads, value, onChange }: Props) {
           variant="tertiary"
           size="small"
           onClick={toggleAll}
-          className="h-7 px-2 text-xs"
+          className="px-2 py-1 text-xs"
         >
           {allSelected ? t('clearAll') : t('selectAll')}
         </Button>
@@ -110,7 +110,7 @@ export function LoadMultiSelect({ loads, value, onChange }: Props) {
                   variant="tertiary"
                   size="small"
                   onClick={() => toggleGroup(group)}
-                  className="h-6 px-2 text-xs"
+                  className="px-2 py-1 text-xs"
                 >
                   {allInGroup ? t('clearAll') : t('selectAll')}
                 </Button>

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Fragment, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -11,53 +12,100 @@ interface Props {
   items: SbpResponsibilityListItem[];
 }
 
+interface Group {
+  key: string;
+  studyingYearName: string;
+  fullName: string;
+  scope: SbpResponsibilityListItem['scope'];
+  subdivisionLabel: string;
+  items: SbpResponsibilityListItem[];
+}
+
+const COLUMN_COUNT = 4;
+
+/**
+ * Lists active SBP grants. Rows are collapsed into (year, full name,
+ * subdivision) groups (KB-1307) — a header row identifies the recipient
+ * and the points they hold are listed underneath.
+ */
 export function RightsTable({ items }: Props) {
   const t = useTranslations('private.studbonuspointsrights');
+
+  const groups = useMemo<Group[]>(() => {
+    const map = new Map<string, Group>();
+    for (const item of items) {
+      const subdivisionLabel = item.subdivisionAbbreviation ?? item.subdivisionName;
+      const key = `${item.studyingYearId}|${item.userAccountId}|${item.subdivisionId}`;
+      let group = map.get(key);
+      if (!group) {
+        group = {
+          key,
+          studyingYearName: item.studyingYearName,
+          fullName: item.fullName,
+          scope: item.scope,
+          subdivisionLabel,
+          items: [],
+        };
+        map.set(key, group);
+      }
+      group.items.push(item);
+    }
+    return [...map.values()];
+  }, [items]);
 
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>{t('table.user')}</TableHead>
-          <TableHead>{t('table.scope')}</TableHead>
-          <TableHead>{t('table.subdivision')}</TableHead>
-          <TableHead>{t('table.year')}</TableHead>
           <TableHead>{t('table.load')}</TableHead>
-          <TableHead>{t('table.created')}</TableHead>
+          <TableHead className="w-40">{t('table.created')}</TableHead>
           <TableHead className="w-12 text-right">
             <span className="sr-only">{t('table.actions')}</span>
           </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {items.map((item) => (
-          <TableRow key={item.id} className="align-top">
-            <TableCell className="font-medium">{item.fullName}</TableCell>
-            <TableCell>
-              <Badge variant={item.scope === 'University' ? 'purple' : 'blue'}>
-                {t(`scope.${item.scope === 'University' ? 'university' : 'faculty'}`)}
-              </Badge>
-            </TableCell>
-            <TableCell>{item.subdivisionAbbreviation ?? item.subdivisionName}</TableCell>
-            <TableCell className="whitespace-nowrap">{item.studyingYearName}</TableCell>
-            <TableCell>
-              <div className="flex flex-col">
-                <span>
-                  {item.loadSubTreeNumber != null ? `${item.loadSubTreeNumber}. ` : ''}
-                  {item.loadName}
-                </span>
-                <span className="text-muted-foreground text-xs">
-                  {item.workKindName} · {item.treeName}
-                </span>
-              </div>
-            </TableCell>
-            <TableCell className="text-muted-foreground whitespace-nowrap">
-              {item.changeDate ? formatDate(item.changeDate) : '—'}
-            </TableCell>
-            <TableCell className="text-right">
-              <RevokeButton item={item} />
-            </TableCell>
-          </TableRow>
+        {groups.map((group) => (
+          <Fragment key={group.key}>
+            <TableRow className="bg-muted/40 hover:bg-muted/40">
+              <TableCell colSpan={COLUMN_COUNT} className="py-2">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span className="text-muted-foreground whitespace-nowrap text-xs uppercase tracking-wide">
+                    {group.studyingYearName}
+                  </span>
+                  <span className="font-medium">{group.fullName}</span>
+                  <Badge variant={group.scope === 'University' ? 'purple' : 'blue'}>
+                    {t(`scope.${group.scope === 'University' ? 'university' : 'faculty'}`)}
+                  </Badge>
+                  <span className="text-muted-foreground text-sm">{group.subdivisionLabel}</span>
+                  <span className="text-muted-foreground ml-auto text-xs">
+                    {t('table.itemsCount', { count: group.items.length })}
+                  </span>
+                </div>
+              </TableCell>
+            </TableRow>
+            {group.items.map((item) => (
+              <TableRow key={item.id} className="align-top">
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span>
+                      {item.loadSubTreeNumber != null ? `${item.loadSubTreeNumber}. ` : ''}
+                      {item.loadName}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {item.workKindName} · {item.treeName}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell className="text-muted-foreground whitespace-nowrap">
+                  {item.changeDate ? formatDate(item.changeDate) : '—'}
+                </TableCell>
+                <TableCell className="text-right">
+                  <RevokeButton item={item} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </Fragment>
         ))}
       </TableBody>
     </Table>

--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
@@ -21,7 +21,7 @@ interface Group {
   items: SbpResponsibilityListItem[];
 }
 
-const COLUMN_COUNT = 4;
+const COLUMN_COUNT = 3;
 
 /**
  * Lists active SBP grants. Rows are collapsed into (year, full name,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -501,7 +501,8 @@
         "year": "Year",
         "load": "Point",
         "created": "Granted",
-        "actions": "Actions"
+        "actions": "Actions",
+        "itemsCount": "{count, plural, one {# point} other {# points}}"
       },
       "filters": {
         "searchPlaceholder": "Search by full name",
@@ -549,6 +550,8 @@
         "loadsSelected": "{count} selected",
         "loadsSearchPlaceholder": "Search a point",
         "loadsNotFound": "No point found.",
+        "selectAll": "Select all",
+        "clearAll": "Clear",
         "submit": "Grant",
         "cancel": "Cancel",
         "errors": {

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -501,7 +501,8 @@
         "year": "Рік",
         "load": "Пункт",
         "created": "Видано",
-        "actions": "Дії"
+        "actions": "Дії",
+        "itemsCount": "{count, plural, one {# пункт} few {# пункти} many {# пунктів} other {# пункту}}"
       },
       "filters": {
         "searchPlaceholder": "Пошук за ПІБ",
@@ -549,6 +550,8 @@
         "loadsSelected": "Обрано пунктів: {count}",
         "loadsSearchPlaceholder": "Пошук пункту",
         "loadsNotFound": "Пункти не знайдено.",
+        "selectAll": "Вибрати все",
+        "clearAll": "Очистити",
         "submit": "Видати",
         "cancel": "Скасувати",
         "errors": {


### PR DESCRIPTION
[KB-1307](https://kpiua.atlassian.net/browse/KB-1307) — UI changes to the SBP rights management interface.

## Summary
- **Grant stage** — `LoadMultiSelect` now has a global Select-all/Clear toggle plus per work-kind/tree group toggles, so admins can pick a whole category of points without hand-checking each row. Selection counter is preserved (\"Обрано пунктів: N\").
- **Review stage** — `RightsTable` collapses rows into (year, full name, subdivision) groups. A header row identifies the recipient (year tag, full name, scope badge, subdivision label, items count) and the loads they hold are listed underneath. Per-row Revoke action is preserved on each load row.
- Translations: adds `grant.selectAll`, `grant.clearAll`, and `table.itemsCount` (uk + en).

## Companion changes
The user-search dropdown will start showing comma-separated subdivision abbreviations for staff after the [backend PR (kb-1307-backend)](https://github.com/kpi-ua/api.campus.kpi.ua/pull/744) lands — no frontend changes are needed for that, the picker just renders whatever label the API returns.

## Test plan
- [x] `npm run tsc` — clean
- [x] `npm run lint` — only pre-existing warnings (unrelated)
- [ ] Smoke: open Grant page, click Select all → all loads selected; click again → all cleared
- [ ] Smoke: open Grant page, expand a work-kind/tree group, use the per-group toggle → only that group's loads change
- [ ] Smoke: open the rights list with several rows for the same person+subdivision+year → rows collapse under one header; revoke action still works on individual loads

## Linked
- Story: [KB-1307](https://kpiua.atlassian.net/browse/KB-1307)
- Backend PR: [api.campus.kpi.ua#744](https://github.com/kpi-ua/api.campus.kpi.ua/pull/744)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KB-1307]: https://kpiua.atlassian.net/browse/KB-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KB-1307]: https://kpiua.atlassian.net/browse/KB-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ