### PR TITLE
KB-1307 Remove misleading per-group items count from SBP rights table

### DIFF
--- a/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
+++ b/src/app/[locale]/(private)/module/studbonuspointsrights/components/rights-table.tsx
@@ -82,9 +82,6 @@ export function RightsTable({ items }: Props) {
                     {t(`scope.${group.scope === 'University' ? 'university' : 'faculty'}`)}
                   </Badge>
                   <span className="text-muted-foreground text-sm">{group.subdivisionLabel}</span>
-                  <span className="text-muted-foreground ml-auto text-xs">
-                    {t('table.itemsCount', { count: group.items.length })}
-                  </span>
                 </div>
               </TableCell>
             </TableRow>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -501,8 +501,7 @@
         "year": "Year",
         "load": "Point",
         "created": "Granted",
-        "actions": "Actions",
-        "itemsCount": "{count, plural, one {# point} other {# points}}"
+        "actions": "Actions"
       },
       "filters": {
         "searchPlaceholder": "Search by full name",

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -501,8 +501,7 @@
         "year": "Рік",
         "load": "Пункт",
         "created": "Видано",
-        "actions": "Дії",
-        "itemsCount": "{count, plural, one {# пункт} few {# пункти} many {# пунктів} other {# пункту}}"
+        "actions": "Дії"
       },
       "filters": {
         "searchPlaceholder": "Пошук за ПІБ",


### PR DESCRIPTION
## Summary
- Drops the `{count} пунктів` badge from each group header in the SBP rights table.
- The count was computed client-side as `group.items.length` over the rows on the **current page** — when a group's grants spilled across pages, the badge underreported (e.g. showed «20 пунктів» for a user with 30 grants).
- Removes the now-unused `private.studbonuspointsrights.table.itemsCount` key from `uk.json` and `en.json`.

## Test plan
- [ ] Open the SBP rights module — group headers no longer show «N пунктів»
- [ ] Per-row revoke and per-user bulk revoke buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)