### PR TITLE
KB-1229 fe campus display read only corporate email in user profile

### DIFF
--- a/src/app/[locale]/(private)/profile/components/contacts-list.tsx
+++ b/src/app/[locale]/(private)/profile/components/contacts-list.tsx
@@ -1,18 +1,30 @@
 import { Paragraph } from '@/components/typography';
 import { EditableField } from '@/app/[locale]/(private)/profile/components/editable-field';
 import { Contact } from '@/types/models/contact';
+import { useTranslations } from 'next-intl';
 
 const PROHIBITED_CONTACT_TYPES = ['orcid id', 'research id', 'scopus id', 'google scholar', 'research gate'] as const;
 
 interface Props {
+  corporateEmail?: string | null;
   contacts: Contact[];
   onUpdateContact: (id: number, typeId: number, value: string) => void;
   onDeleteContact: (id: number) => void;
 }
 
-export default function ContactsList({ contacts, onUpdateContact, onDeleteContact }: Props) {
+export default function ContactsList({ corporateEmail, contacts, onUpdateContact, onDeleteContact }: Props) {
+  const t = useTranslations('private.profile');
+
   return (
     <div className="flex w-full flex-col gap-4">
+      <div className="flex flex-col items-start gap-4 xl:flex-row xl:items-center">
+        <Paragraph className="m-0 w-full max-w-[250px] min-w-[170px] font-semibold text-neutral-400 xl:max-w-[220px]">
+          {t('contact.corporate-email')}:
+        </Paragraph>
+        <Paragraph className="m-0 min-w-[170px] font-medium break-all">
+          {corporateEmail?.trim() || t('placeholder.not-specified')}
+        </Paragraph>
+      </div>
       {contacts.map((contact) => {
         const isReadonly = PROHIBITED_CONTACT_TYPES.find(
           (readOnlyContact) => readOnlyContact.toLowerCase() === contact.type.name.toLowerCase(),

--- a/src/app/[locale]/(private)/profile/components/contacts.tsx
+++ b/src/app/[locale]/(private)/profile/components/contacts.tsx
@@ -15,11 +15,12 @@ import { useTranslations } from 'next-intl';
 import ContactsList from '@/app/[locale]/(private)/profile/components/contacts-list';
 
 interface Props {
+  corporateEmail?: string | null;
   contacts: Contact[];
   contactTypes: ContactType[];
 }
 
-export function Contacts({ contacts, contactTypes }: Props) {
+export function Contacts({ corporateEmail, contacts, contactTypes }: Props) {
   const t = useTranslations('private.profile');
 
   const FormSchema = z.object({
@@ -56,7 +57,12 @@ export function Contacts({ contacts, contactTypes }: Props) {
       <div className="flex w-full flex-col gap-3">
         <Heading6>{t('contact.title')}</Heading6>
         <Separator />
-        <ContactsList contacts={contacts} onDeleteContact={handleDeleteContact} onUpdateContact={handleUpdateContact} />
+        <ContactsList
+          corporateEmail={corporateEmail}
+          contacts={contacts}
+          onDeleteContact={handleDeleteContact}
+          onUpdateContact={handleUpdateContact}
+        />
       </div>
 
       <div className="mt-6 flex flex-col gap-3">

--- a/src/app/[locale]/(private)/profile/page.tsx
+++ b/src/app/[locale]/(private)/profile/page.tsx
@@ -40,7 +40,7 @@ export default async function Page() {
           <InfoBlock user={user} className="h-fit w-full" />
           <Card className="h-fit w-full">
             <CardContent className="flex flex-col gap-6 space-y-1.5 p-9">
-              <Contacts contacts={contacts} contactTypes={contactTypes} />
+              <Contacts corporateEmail={user.corporateEmail} contacts={contacts} contactTypes={contactTypes} />
               {user.intellectProfile && <IntellectPublicationInfo user={user} />}
               <CodeOfHonor user={user} />
             </CardContent>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -506,6 +506,7 @@
       },
       "contact": {
         "title": "Contact",
+        "corporate-email": "Corporate email",
         "add-contact": "Add contact",
         "contact-type": "Contact Type",
         "choose-contact-type": "Choose contact type",

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -506,6 +506,7 @@
       },
       "contact": {
         "title": "Контакт",
+        "corporate-email": "Корпоративна електронна пошта",
         "add-contact": "Додати контакт",
         "contact-type": "Вид контакту",
         "choose-contact-type": "Оберіть вид контакту",

--- a/src/types/models/user.ts
+++ b/src/types/models/user.ts
@@ -6,6 +6,7 @@ export interface User {
   id: number;
   username: string;
   email: string;
+  corporateEmail?: string | null;
   scientificInterests?: string;
   userIdentifier: string;
   fullName: string;


### PR DESCRIPTION
This pull request updates the profile contacts section to display the user's corporate email in addition to their contact list. The changes ensure the corporate email is shown in a read-only format at the top of the contacts list, and translations for "corporate email" are added in both English and Ukrainian. The `User` type is also updated to include the optional `corporateEmail` field.

**Profile UI enhancements:**

* The `ContactsList` component now displays the user's corporate email above the contact list, using the new `corporateEmail` prop. The value is shown as read-only and falls back to a "not specified" placeholder if missing. (`src/app/[locale]/(private)/profile/components/contacts-list.tsx`) ([src/app/[locale]/(private)/profile/components/contacts-list.tsxR4-R27](diffhunk://#diff-7a42d79f73d9baa59fc61998700f296fb5ca8c6496fd8ab147b75ee2ac44bd5dR4-R27))
* The `Contacts` component and its usage are updated to accept and pass down the `corporateEmail` prop to `ContactsList`. (`src/app/[locale]/(private)/profile/components/contacts.tsx`, `src/app/[locale]/(private)/profile/page.tsx`) ([src/app/[locale]/(private)/profile/components/contacts.tsxR18-R23](diffhunk://#diff-46bc9db09fba723299f6eda60b23b6ffbc571c6eaa25db1bad17c092622d407eR18-R23), [src/app/[locale]/(private)/profile/components/contacts.tsxL59-R65](diffhunk://#diff-46bc9db09fba723299f6eda60b23b6ffbc571c6eaa25db1bad17c092622d407eL59-R65), [src/app/[locale]/(private)/profile/page.tsxL43-R43](diffhunk://#diff-f67684b4a45a130ac1003ed216ba5543180fc53fc9acb1f8f6650fce77595e6dL43-R43))

**Internationalization:**

* Added "corporate email" translations in both English and Ukrainian message files to support the new label in the UI. (`src/messages/en.json`, `src/messages/uk.json`) [[1]](diffhunk://#diff-8a2b44aca2c0d795c5537b872cf5ea0a558605c608e56e90837e96ad257817f2R509) [[2]](diffhunk://#diff-040c126e576b52a419d812df14190df90f8db9e4d8e2611a4ef537b5c027713bR509)

**Type updates:**

* The `User` interface is extended to include an optional `corporateEmail` field to support passing this data through the profile components. (`src/types/models/user.ts`)