### PR TITLE
KB-1408 Implement K-7 report preview page

### DIFF
--- a/src/actions/k7-form.actions.ts
+++ b/src/actions/k7-form.actions.ts
@@ -3,7 +3,56 @@
 import qs from 'query-string';
 
 import { campusFetch } from '@/lib/client';
-import { K7FormFilters, K7ReportRequest } from '@/types/models/k7-form';
+import {
+  K7_ACHIEVEMENT_WORK_TYPE,
+  K7FormFilters,
+  K7HtmlPreview,
+  K7ReportRequest,
+  K7ReportRequestDetails,
+} from '@/types/models/k7-form';
+
+const normalizeK7FormPreview = (response: K7ReportRequestDetails): K7HtmlPreview => {
+  const teachingDisciplines = response.teachingDisciplines ?? [];
+  const otherEducationalActivities = response.otherEducationalActivities ?? [];
+  const detailedAchievements = response.detailedAchievements ?? [];
+
+  const achievementsByWorkType = Object.groupBy(detailedAchievements, ({ workType }) => workType);
+  const scientificAchievements = [
+    ...(achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Scientific] ?? []),
+    ...(achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Article] ?? []),
+  ];
+  const methodicalAchievements = [
+    ...(achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Methodical] ?? []),
+    ...(achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Syllabus] ?? []),
+  ];
+  const organizationalAchievements = achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Organizational] ?? [];
+  const otherAchievements = achievementsByWorkType[K7_ACHIEVEMENT_WORK_TYPE.Other] ?? [];
+
+  const educationalHours =
+    teachingDisciplines.reduce((total, item) => total + item.totalVolume, 0) +
+    otherEducationalActivities.reduce((total, item) => total + item.grandTotal, 0);
+  const scientificHours = scientificAchievements.reduce((total, item) => total + item.hoursUsed, 0);
+  const methodicalHours = methodicalAchievements.reduce((total, item) => total + item.hoursUsed, 0);
+  const organizationalHours = organizationalAchievements.reduce((total, item) => total + item.hoursUsed, 0);
+  const otherHours = otherAchievements.reduce((total, item) => total + item.hoursUsed, 0);
+
+  return {
+    header: response.header,
+    section1: { teachingDisciplines, otherEducationalActivities },
+    section2: scientificAchievements,
+    section3: methodicalAchievements,
+    section4: organizationalAchievements,
+    section5: otherAchievements,
+    section6: {
+      educationalHours,
+      scientificHours,
+      methodicalHours,
+      organizationalHours,
+      otherHours,
+      totalHours: educationalHours + scientificHours + methodicalHours + organizationalHours + otherHours,
+    },
+  };
+};
 
 export const getK7FormFilters = async (targetAccountId?: number): Promise<K7FormFilters> => {
   const url = qs.stringifyUrl({ url: '/k7-form/filters', query: { targetAccountId } });
@@ -24,4 +73,14 @@ export const getK7FormRequests = async (all = false): Promise<K7ReportRequest[]>
   }
 
   return response.json();
+};
+
+export const getK7FormPreview = async (requestId: string): Promise<K7HtmlPreview> => {
+  const response = await campusFetch<K7ReportRequestDetails>(`/k7-form/requests/${requestId}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch K-7 preview: ${response.status} ${response.statusText}`);
+  }
+
+  return normalizeK7FormPreview(await response.json());
 };

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/department-work-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/department-work-table.tsx
@@ -1,0 +1,65 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatNumber } from '@/lib/utils';
+import { K7DetailedAchievement } from '@/types/models/k7-form';
+
+import { EmptyTableRow } from './empty-table-row';
+import { summaryCellClassName, summaryRowClassName, tableCellClassName, tableHeadClassName } from './table-styles';
+
+interface Props {
+  rows: K7DetailedAchievement[];
+}
+
+export const DepartmentWorkTable = ({ rows }: Props) => (
+  <Table className="table-fixed border-collapse text-[12px] leading-[16px]">
+    <colgroup>
+      <col className="w-[5%]" />
+      <col className="w-[22%]" />
+      <col className="w-[35%]" />
+      <col className="w-[8%]" />
+      <col className="w-[18%]" />
+      <col className="w-[12%]" />
+    </colgroup>
+    <TableHeader>
+      <TableRow className="hover:bg-white">
+        <TableHead className={tableHeadClassName}>№</TableHead>
+        <TableHead className={tableHeadClassName}>Вид роботи</TableHead>
+        <TableHead className={tableHeadClassName}>Опис виконаної роботи</TableHead>
+        <TableHead className={`${tableHeadClassName} text-right [&>span]:justify-end`}>Год.</TableHead>
+        <TableHead className={tableHeadClassName}>Підтвердження</TableHead>
+        <TableHead className={tableHeadClassName}>Підрозділ</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {rows.length === 0 && <EmptyTableRow colSpan={6} />}
+      {rows.map((row, index) => (
+        <TableRow key={`${row.workType}-${row.workDescription}-${index}`} className="hover:bg-white">
+          <TableCell className={tableCellClassName}>{index + 1}</TableCell>
+          <TableCell className={`${tableCellClassName} [overflow-wrap:anywhere]`}>{row.workTypeDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} [overflow-wrap:anywhere]`}>{row.workDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} text-right whitespace-nowrap`}>
+            {formatNumber(row.hoursUsed, 2)}
+          </TableCell>
+          <TableCell className={`${tableCellClassName} [overflow-wrap:anywhere] whitespace-normal`}>
+            {row.proofOfPerformance || '—'}
+          </TableCell>
+          <TableCell className={`${tableCellClassName} [overflow-wrap:anywhere]`}>
+            {row.responsibleDepartment || '—'}
+          </TableCell>
+        </TableRow>
+      ))}
+      {rows.length > 0 && (
+        <TableRow className={summaryRowClassName}>
+          <TableCell colSpan={5} className={summaryCellClassName}>
+            Разом
+          </TableCell>
+          <TableCell className={`${summaryCellClassName} text-right`}>
+            {formatNumber(
+              rows.reduce((total, row) => total + row.hoursUsed, 0),
+              0,
+            )}
+          </TableCell>
+        </TableRow>
+      )}
+    </TableBody>
+  </Table>
+);

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/download-pdf-button.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/download-pdf-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/components/ui/button';
+
+export const DownloadPdfButton = () => {
+  const t = useTranslations('private.k-reports.k-7.actions');
+
+  return (
+    <Button
+      type="button"
+      size="small"
+      className="h-8 shrink-0 px-3 py-0 text-[12px] leading-[16px] active:px-[11px] active:py-0"
+    >
+      {t('downloadPdf')}
+    </Button>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/empty-table-row.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/empty-table-row.tsx
@@ -1,0 +1,13 @@
+import { TableCell, TableRow } from '@/components/ui/table';
+
+interface Props {
+  colSpan: number;
+}
+
+export const EmptyTableRow = ({ colSpan }: Props) => (
+  <TableRow>
+    <TableCell colSpan={colSpan} className="py-8 text-center text-xs text-neutral-500">
+      Немає даних
+    </TableCell>
+  </TableRow>
+);

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/methodical-work-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/methodical-work-table.tsx
@@ -1,0 +1,60 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatNumber } from '@/lib/utils';
+import { K7DetailedAchievement } from '@/types/models/k7-form';
+
+import { EmptyTableRow } from './empty-table-row';
+import { summaryCellClassName, summaryRowClassName, tableCellClassName, tableHeadClassName } from './table-styles';
+
+interface Props {
+  rows: K7DetailedAchievement[];
+}
+
+export const MethodicalWorkTable = ({ rows }: Props) => (
+  <Table className="table-fixed border-collapse text-[12px] leading-[16px]">
+    <colgroup>
+      <col className="w-[5%]" />
+      <col className="w-[20%]" />
+      <col className="w-[38%]" />
+      <col className="w-[29%]" />
+      <col className="w-[8%]" />
+    </colgroup>
+    <TableHeader>
+      <TableRow className="hover:bg-white">
+        <TableHead className={tableHeadClassName}>№</TableHead>
+        <TableHead className={tableHeadClassName}>Вид роботи</TableHead>
+        <TableHead className={tableHeadClassName}>Опис</TableHead>
+        <TableHead className={tableHeadClassName}>Підтвердження</TableHead>
+        <TableHead className={`${tableHeadClassName} text-right [&>span]:justify-end`}>Годин</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {rows.length === 0 && <EmptyTableRow colSpan={5} />}
+      {rows.map((row, index) => (
+        <TableRow key={`${row.workType}-${row.workDescription}-${index}`} className="hover:bg-white">
+          <TableCell className={tableCellClassName}>{index + 1}</TableCell>
+          <TableCell className={`${tableCellClassName} wrap-anywhere`}>{row.workTypeDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} wrap-anywhere`}>{row.workDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} wrap-anywhere whitespace-normal`}>
+            {row.proofOfPerformance || '—'}
+          </TableCell>
+          <TableCell className={`${tableCellClassName} text-right whitespace-nowrap`}>
+            {formatNumber(row.hoursUsed, 2)}
+          </TableCell>
+        </TableRow>
+      ))}
+      {rows.length > 0 && (
+        <TableRow className={summaryRowClassName}>
+          <TableCell colSpan={4} className={summaryCellClassName}>
+            Разом
+          </TableCell>
+          <TableCell className={`${summaryCellClassName} text-right`}>
+            {formatNumber(
+              rows.reduce((total, row) => total + row.hoursUsed, 0),
+              0,
+            )}
+          </TableCell>
+        </TableRow>
+      )}
+    </TableBody>
+  </Table>
+);

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/organizational-work-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/organizational-work-table.tsx
@@ -1,0 +1,9 @@
+import { K7DetailedAchievement } from '@/types/models/k7-form';
+
+import { DepartmentWorkTable } from './department-work-table';
+
+interface Props {
+  rows: K7DetailedAchievement[];
+}
+
+export const OrganizationalWorkTable = ({ rows }: Props) => <DepartmentWorkTable rows={rows} />;

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/other-activities-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/other-activities-table.tsx
@@ -1,0 +1,135 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn, formatNumber } from '@/lib/utils';
+import { K7OtherEducationalActivity } from '@/types/models/k7-form';
+
+import { EDUCATION_LEVEL_TITLES } from '../constants';
+import { groupOtherActivities } from '../utils/group-other-activities';
+import { EmptyTableRow } from './empty-table-row';
+import { summaryCellClassName, summaryRowClassName, tableCellClassName, tableHeadClassName } from './table-styles';
+
+interface Props {
+  rows: K7OtherEducationalActivity[];
+}
+
+const hasSemesterData = (groupCodes: string | null, studentCount: number, hours: number) =>
+  Boolean(groupCodes) || studentCount > 0 || hours > 0;
+
+const formatSemesterHours = (hours: number) => (hours > 0 ? formatNumber(hours, 2) : '—');
+
+export const OtherActivitiesTable = ({ rows }: Props) => {
+  const semesterHeadClassName = cn(tableHeadClassName, 'h-[32px] text-center');
+  const borderedSemesterHeadClassName = cn(semesterHeadClassName, 'border-neutral-divider border-x');
+  const activityGroups = groupOtherActivities(rows);
+
+  return (
+    <Table className="table-fixed border-collapse text-[12px] leading-[16px] [&_td:not(:last-child)]:border-r">
+      <colgroup>
+        <col className="w-[4%]" />
+        <col className="w-[23%]" />
+        <col className="w-[8%]" />
+        <col className="w-[4%]" />
+        <col className="w-[8%]" />
+        <col className="w-[10%]" />
+        <col className="w-[5%]" />
+        <col className="w-[4%]" />
+        <col className="w-[8%]" />
+        <col className="w-[10%]" />
+        <col className="w-[5%]" />
+        <col className="w-[11%]" />
+      </colgroup>
+      <TableHeader>
+        <TableRow className="hover:bg-white">
+          <TableHead rowSpan={2} className={tableHeadClassName}>
+            №
+          </TableHead>
+          <TableHead rowSpan={2} colSpan={2} className={tableHeadClassName}>
+            Вид роботи
+          </TableHead>
+          <TableHead colSpan={4} className={borderedSemesterHeadClassName}>
+            1 семестр
+          </TableHead>
+          <TableHead colSpan={4} className={borderedSemesterHeadClassName}>
+            2 семестр
+          </TableHead>
+          <TableHead rowSpan={2} className={tableHeadClassName}>
+            Разом за рік
+          </TableHead>
+        </TableRow>
+        <TableRow className="hover:bg-white">
+          <TableHead className={borderedSemesterHeadClassName}>Курс</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>Шифри груп</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>К-сть здобувачів</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>Годин</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>Курс</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>Шифри груп</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>К-сть здобувачів</TableHead>
+          <TableHead className={borderedSemesterHeadClassName}>Годин</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.length === 0 && <EmptyTableRow colSpan={12} />}
+        {activityGroups.map((group, groupIndex) =>
+          group.rows.map((row, rowIndex) => {
+            const hasFirstSemesterData = hasSemesterData(row.groupCodesSem1, row.studentCountSem1, row.hoursSem1);
+            const hasSecondSemesterData = hasSemesterData(row.groupCodesSem2, row.studentCountSem2, row.hoursSem2);
+
+            return (
+              <TableRow
+                key={`${group.workType}-${row.course}-${row.groupCodesSem1}-${row.groupCodesSem2}-${rowIndex}`}
+                className="hover:bg-white"
+              >
+                {rowIndex === 0 && (
+                  <>
+                    <TableCell rowSpan={group.rows.length} className={tableCellClassName}>
+                      {groupIndex + 1}
+                    </TableCell>
+                    <TableCell rowSpan={group.rows.length} className={tableCellClassName}>
+                      {group.workType}
+                    </TableCell>
+                  </>
+                )}
+                <TableCell className={tableCellClassName}>{EDUCATION_LEVEL_TITLES[row.educationLevel]}</TableCell>
+                <TableCell className={tableCellClassName}>{hasFirstSemesterData ? (row.course ?? '—') : '—'}</TableCell>
+                <TableCell className={tableCellClassName}>{row.groupCodesSem1 || '—'}</TableCell>
+                <TableCell className={tableCellClassName}>
+                  {hasFirstSemesterData ? row.studentCountSem1 : '—'}
+                </TableCell>
+                <TableCell className={tableCellClassName}>{formatSemesterHours(row.hoursSem1)}</TableCell>
+                <TableCell className={tableCellClassName}>
+                  {hasSecondSemesterData ? (row.course ?? '—') : '—'}
+                </TableCell>
+                <TableCell className={tableCellClassName}>{row.groupCodesSem2 || '—'}</TableCell>
+                <TableCell className={tableCellClassName}>
+                  {hasSecondSemesterData ? row.studentCountSem2 : '—'}
+                </TableCell>
+                <TableCell className={tableCellClassName}>{formatSemesterHours(row.hoursSem2)}</TableCell>
+                <TableCell className={tableCellClassName}>{formatNumber(row.grandTotal, 2)}</TableCell>
+              </TableRow>
+            );
+          }),
+        )}
+        {rows.length > 0 && (
+          <TableRow className={summaryRowClassName}>
+            <TableCell colSpan={3} className={summaryCellClassName}>
+              Разом
+            </TableCell>
+            <TableCell colSpan={3} className={summaryCellClassName} />
+            <TableCell className={summaryCellClassName}>
+              {formatSemesterHours(rows.reduce((total, row) => total + row.hoursSem1, 0))}
+            </TableCell>
+            <TableCell colSpan={3} className={summaryCellClassName} />
+            <TableCell className={summaryCellClassName}>
+              {formatSemesterHours(rows.reduce((total, row) => total + row.hoursSem2, 0))}
+            </TableCell>
+            <TableCell className={summaryCellClassName}>
+              {formatNumber(
+                rows.reduce((total, row) => total + row.grandTotal, 0),
+                2,
+              )}
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/other-duties-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/other-duties-table.tsx
@@ -1,0 +1,55 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatNumber } from '@/lib/utils';
+import { K7DetailedAchievement } from '@/types/models/k7-form';
+
+import { EmptyTableRow } from './empty-table-row';
+import { summaryCellClassName, summaryRowClassName, tableCellClassName, tableHeadClassName } from './table-styles';
+
+interface Props {
+  rows: K7DetailedAchievement[];
+}
+
+export const OtherDutiesTable = ({ rows }: Props) => (
+  <Table className="table-fixed border-collapse text-[12px] leading-[16px]">
+    <colgroup>
+      <col className="w-[5%]" />
+      <col className="w-[27%]" />
+      <col className="w-[60%]" />
+      <col className="w-[8%]" />
+    </colgroup>
+    <TableHeader>
+      <TableRow className="hover:bg-white">
+        <TableHead className={tableHeadClassName}>№</TableHead>
+        <TableHead className={tableHeadClassName}>Вид роботи</TableHead>
+        <TableHead className={tableHeadClassName}>Опис</TableHead>
+        <TableHead className={`${tableHeadClassName} text-right [&>span]:justify-end`}>Годин</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {rows.length === 0 && <EmptyTableRow colSpan={4} />}
+      {rows.map((row, index) => (
+        <TableRow key={`${row.workType}-${row.workDescription}-${index}`} className="hover:bg-white">
+          <TableCell className={tableCellClassName}>{index + 1}</TableCell>
+          <TableCell className={`${tableCellClassName} [overflow-wrap:anywhere]`}>{row.workTypeDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} wrap-anywhere`}>{row.workDescription}</TableCell>
+          <TableCell className={`${tableCellClassName} text-right whitespace-nowrap`}>
+            {formatNumber(row.hoursUsed, 2)}
+          </TableCell>
+        </TableRow>
+      ))}
+      {rows.length > 0 && (
+        <TableRow className={summaryRowClassName}>
+          <TableCell colSpan={3} className={summaryCellClassName}>
+            Разом
+          </TableCell>
+          <TableCell className={`${summaryCellClassName} text-right`}>
+            {formatNumber(
+              rows.reduce((total, row) => total + row.hoursUsed, 0),
+              0,
+            )}
+          </TableCell>
+        </TableRow>
+      )}
+    </TableBody>
+  </Table>
+);

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/report-section.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/report-section.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { Books, CaretUpRegular } from '@/app/images';
+import { cn, formatNumber } from '@/lib/utils';
+
+interface Props {
+  number: string;
+  title: string;
+  hours: number;
+  summaryText?: string;
+  children: ReactNode;
+}
+
+export const ReportSection = ({ number, title, hours, summaryText, children }: Props) => {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <section className="border-neutral-divider min-w-0 overflow-hidden rounded-[6px] border bg-white">
+      <div className="border-neutral-divider flex min-h-[40px] items-center gap-3 border-b px-4 py-[11px]">
+        <Books className="text-basic-blue size-[16px] shrink-0" />
+        <span className="min-w-0 text-[12px] leading-[16px] font-semibold text-neutral-900">
+          Розділ {number}. — {title}
+        </span>
+        <span className="ml-auto shrink-0 pl-2 text-[12px] leading-[16px] font-semibold text-neutral-900">
+          {summaryText ?? `${formatNumber(hours, 0)} год.`}
+        </span>
+        <button
+          className="flex size-[24px] shrink-0 cursor-pointer items-center justify-center rounded-[4px] text-neutral-600 transition-colors hover:bg-neutral-50 hover:text-neutral-900"
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <CaretUpRegular className={cn('size-[16px] transition-transform', !expanded && 'rotate-180')} />
+        </button>
+      </div>
+      {expanded && children}
+    </section>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/scientific-work-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/scientific-work-table.tsx
@@ -1,0 +1,9 @@
+import { K7DetailedAchievement } from '@/types/models/k7-form';
+
+import { DepartmentWorkTable } from './department-work-table';
+
+interface Props {
+  rows: K7DetailedAchievement[];
+}
+
+export const ScientificWorkTable = ({ rows }: Props) => <DepartmentWorkTable rows={rows} />;

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/summary-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/summary-table.tsx
@@ -1,0 +1,44 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatNumber } from '@/lib/utils';
+import { K7HtmlPreview } from '@/types/models/k7-form';
+
+import { summaryCellClassName, summaryRowClassName, tableCellClassName, tableHeadClassName } from './table-styles';
+
+interface Props {
+  preview: K7HtmlPreview;
+}
+
+export const SummaryTable = ({ preview }: Props) => {
+  const rows = [
+    { title: 'Навчальна робота', hours: preview.section6.educationalHours },
+    { title: 'Наукова робота', hours: preview.section6.scientificHours },
+    { title: 'Методична робота', hours: preview.section6.methodicalHours },
+    { title: 'Організаційна робота', hours: preview.section6.organizationalHours },
+    { title: "Інші трудові обов'язки", hours: preview.section6.otherHours },
+  ];
+
+  return (
+    <Table className="table-fixed border-collapse text-[12px] leading-[16px]">
+      <TableHeader>
+        <TableRow className="hover:bg-white">
+          <TableHead className={tableHeadClassName}>Вид роботи</TableHead>
+          <TableHead className={`${tableHeadClassName} text-right [&>span]:justify-end`}>Годин</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row) => (
+          <TableRow key={row.title} className="hover:bg-white">
+            <TableCell className={tableCellClassName}>{row.title}</TableCell>
+            <TableCell className={`${tableCellClassName} text-right`}>{formatNumber(row.hours, 2)}</TableCell>
+          </TableRow>
+        ))}
+        <TableRow className={summaryRowClassName}>
+          <TableCell className={summaryCellClassName}>Загальне навантаження</TableCell>
+          <TableCell className={`${summaryCellClassName} text-right`}>
+            {formatNumber(preview.section6.totalHours, 2)}
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/table-styles.ts
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/table-styles.ts
@@ -1,0 +1,7 @@
+export const tableHeadClassName =
+  'border-neutral-divider h-[48px] bg-white px-3 py-0 text-[12px] leading-[15px] font-medium normal-case text-neutral-500';
+export const tableCellClassName =
+  'border-neutral-divider px-3 py-[10px] text-[12px] leading-[16px] align-middle text-neutral-900';
+export const summaryCellClassName = 'border-neutral-divider px-4 py-[10px] text-[12px] leading-[16px] font-semibold';
+export const summaryRowClassName = 'bg-[#f0f1fb] hover:bg-[#f0f1fb]';
+export const semesterRowClassName = 'bg-[#f7f8fc] hover:bg-[#f7f8fc]';

--- a/src/app/[locale]/(k-reports)/k-7/preview/components/teaching-disciplines-table.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/components/teaching-disciplines-table.tsx
@@ -1,0 +1,113 @@
+import { Fragment } from 'react';
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn, formatNumber } from '@/lib/utils';
+import { K7TeachingDiscipline } from '@/types/models/k7-form';
+
+import { EmptyTableRow } from './empty-table-row';
+import {
+  semesterRowClassName,
+  summaryCellClassName,
+  summaryRowClassName,
+  tableCellClassName,
+  tableHeadClassName,
+} from './table-styles';
+
+interface Props {
+  rows: K7TeachingDiscipline[];
+}
+
+export const TeachingDisciplinesTable = ({ rows }: Props) => {
+  const semesters = [...new Set(rows.map((row) => row.semester))].sort((a, b) => a - b);
+  const teachingTableHeadClassName = cn(tableHeadClassName, 'h-[72px] align-middle');
+
+  return (
+    <Table className="table-fixed border-collapse text-[12px] leading-[16px]">
+      <colgroup>
+        <col className="w-[4%]" />
+        <col className="w-[31%]" />
+        <col className="w-[12%]" />
+        <col className="w-[15%]" />
+        <col className="w-[14%]" />
+        <col className="w-[13%]" />
+        <col className="w-[11%]" />
+      </colgroup>
+      <TableHeader>
+        <TableRow className="hover:bg-white">
+          <TableHead className={teachingTableHeadClassName}>№</TableHead>
+          <TableHead className={teachingTableHeadClassName}>
+            Факультет (ННІ), який забезпечується потоку; абрев., назва освітнього компонента
+          </TableHead>
+          <TableHead className={teachingTableHeadClassName}>Ідентифікатор потоку</TableHead>
+          <TableHead className={teachingTableHeadClassName}>Шифри академічних груп у потоці, к-сть студентів</TableHead>
+          <TableHead className={teachingTableHeadClassName}>Обсяг освітнього компонента за семестр</TableHead>
+          <TableHead className={teachingTableHeadClassName}>К-сть навч. груп практ.</TableHead>
+          <TableHead className={teachingTableHeadClassName}>К-сть навч. груп лаб.</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {semesters.length === 0 && <EmptyTableRow colSpan={7} />}
+        {semesters.map((semester) => {
+          const semesterRows = rows.filter((row) => row.semester === semester);
+
+          return (
+            <Fragment key={semester}>
+              <TableRow className={semesterRowClassName}>
+                <TableCell colSpan={7} className={summaryCellClassName}>
+                  {semester} семестр
+                </TableCell>
+              </TableRow>
+              {semesterRows.map((row, index) => (
+                <TableRow key={`${row.subjectName}-${row.streamId}-${index}`} className="hover:bg-white">
+                  <TableCell className={tableCellClassName}>{index + 1}</TableCell>
+                  <TableCell className={tableCellClassName}>{row.subjectName}</TableCell>
+                  <TableCell className={tableCellClassName}>{row.streamId || '—'}</TableCell>
+                  <TableCell className={tableCellClassName}>{row.groupCodes || '—'}</TableCell>
+                  <TableCell className={tableCellClassName}>{formatNumber(row.totalVolume, 2)}</TableCell>
+                  <TableCell className={tableCellClassName}>{row.practiceGroupsCount}</TableCell>
+                  <TableCell className={tableCellClassName}>{row.labGroupsCount}</TableCell>
+                </TableRow>
+              ))}
+              <TableRow className={summaryRowClassName}>
+                <TableCell colSpan={4} className={summaryCellClassName}>
+                  Разом за {semester} семестр
+                </TableCell>
+                <TableCell className={summaryCellClassName}>
+                  {formatNumber(
+                    semesterRows.reduce((total, row) => total + row.totalVolume, 0),
+                    2,
+                  )}
+                </TableCell>
+                <TableCell className={summaryCellClassName}>
+                  {semesterRows.reduce((total, row) => total + row.practiceGroupsCount, 0)}
+                </TableCell>
+                <TableCell className={summaryCellClassName}>
+                  {semesterRows.reduce((total, row) => total + row.labGroupsCount, 0)}
+                </TableCell>
+              </TableRow>
+            </Fragment>
+          );
+        })}
+        {rows.length > 0 && (
+          <TableRow className={summaryRowClassName}>
+            <TableCell colSpan={4} className={summaryCellClassName}>
+              Разом за навчальний рік
+            </TableCell>
+            <TableCell className={summaryCellClassName}>
+              {formatNumber(
+                rows.reduce((total, row) => total + row.totalVolume, 0),
+                2,
+              )}
+            </TableCell>
+            <TableCell className={summaryCellClassName}>
+              {rows.reduce((total, row) => total + row.practiceGroupsCount, 0)}
+            </TableCell>
+            <TableCell className={summaryCellClassName}>
+              {rows.reduce((total, row) => total + row.labGroupsCount, 0)}
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/constants.ts
+++ b/src/app/[locale]/(k-reports)/k-7/preview/constants.ts
@@ -1,0 +1,16 @@
+import { K7_EDUCATION_LEVEL, K7EducationLevel } from '@/types/models/k7-form';
+
+type EmployeeCategoryTranslationKey = 'npp' | 'pp';
+
+export const EMPLOYEE_CATEGORY_TRANSLATION_KEYS: Record<string, EmployeeCategoryTranslationKey> = {
+  NPP: 'npp',
+  PP: 'pp',
+};
+
+export const EDUCATION_LEVEL_TITLES: Record<K7EducationLevel, string> = {
+  [K7_EDUCATION_LEVEL.Bachelor]: 'бакалаврів',
+  [K7_EDUCATION_LEVEL.MasterProfessional]: 'магістрів ОПП',
+  [K7_EDUCATION_LEVEL.MasterScientific]: 'магістрів ОНП',
+  [K7_EDUCATION_LEVEL.PhD]: 'аспірантів',
+  [K7_EDUCATION_LEVEL.Other]: 'інше',
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/page.content.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/page.content.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { CaretLeftRegular } from '@/app/images';
+import { Heading2, Paragraph } from '@/components/typography';
+import { Link } from '@/i18n/routing';
+import { formatNumber } from '@/lib/utils';
+import { K7HtmlPreview } from '@/types/models/k7-form';
+
+import { DownloadPdfButton } from './components/download-pdf-button';
+import { MethodicalWorkTable } from './components/methodical-work-table';
+import { OrganizationalWorkTable } from './components/organizational-work-table';
+import { OtherActivitiesTable } from './components/other-activities-table';
+import { OtherDutiesTable } from './components/other-duties-table';
+import { ReportSection } from './components/report-section';
+import { ScientificWorkTable } from './components/scientific-work-table';
+import { SummaryTable } from './components/summary-table';
+import { TeachingDisciplinesTable } from './components/teaching-disciplines-table';
+import { EMPLOYEE_CATEGORY_TRANSLATION_KEYS } from './constants';
+
+interface Props {
+  preview: K7HtmlPreview;
+}
+
+export const K7PreviewContent = ({ preview }: Props) => {
+  const tEmployeeCategory = useTranslations('private.k-reports.k-7.employee-category');
+  const teachingHours = preview.section1.teachingDisciplines.reduce((total, row) => total + row.totalVolume, 0);
+  const otherEducationalHours = preview.section1.otherEducationalActivities.reduce(
+    (total, row) => total + row.grandTotal,
+    0,
+  );
+  const normalizedEmployeeCategory = preview.header.employeeCategory.trim().toUpperCase();
+  const employeeCategoryTranslationKey = EMPLOYEE_CATEGORY_TRANSLATION_KEYS[normalizedEmployeeCategory];
+  const employeeCategory = employeeCategoryTranslationKey
+    ? tEmployeeCategory(employeeCategoryTranslationKey)
+    : preview.header.employeeCategory;
+  const academicYear = `${preview.header.year}-${preview.header.year + 1}`;
+
+  return (
+    <main className="flex w-full min-w-0 flex-col">
+      <Link
+        href="/k-7"
+        className="mb-[14px] inline-flex w-fit items-center gap-2 text-[12px] leading-[16px] font-semibold text-neutral-500"
+      >
+        <CaretLeftRegular className="size-[16px]" />
+        Назад
+      </Link>
+
+      <div className="mb-[20px] flex min-w-0 flex-col items-start justify-between gap-3 sm:flex-row">
+        <div className="min-w-0">
+          <Heading2 className="text-[18px] leading-[22px] text-neutral-900 lg:text-[18px] lg:leading-[22px]">
+            Звіт К-7 · {preview.header.totalEmploymentRate} ст. · {employeeCategory}
+          </Heading2>
+          <Paragraph className="mt-2 mb-0 text-[12px] !leading-[16px] font-medium text-neutral-500">
+            {preview.header.fullName} · {preview.header.position} · {preview.header.departmentName} · {academicYear}
+          </Paragraph>
+        </div>
+        <DownloadPdfButton />
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-2">
+        <ReportSection number="1.1" title="Викладання освітніх компонентів" hours={teachingHours}>
+          <TeachingDisciplinesTable rows={preview.section1.teachingDisciplines} />
+        </ReportSection>
+
+        <ReportSection number="1.2" title="Інші види навчальної роботи" hours={otherEducationalHours}>
+          <OtherActivitiesTable rows={preview.section1.otherEducationalActivities} />
+        </ReportSection>
+
+        <div className="mt-8 flex min-w-0 flex-col gap-2">
+          <ReportSection number="2" title="Наукова робота" hours={preview.section6.scientificHours}>
+            <ScientificWorkTable rows={preview.section2} />
+          </ReportSection>
+
+          <ReportSection number="3" title="Методична робота" hours={preview.section6.methodicalHours}>
+            <MethodicalWorkTable rows={preview.section3} />
+          </ReportSection>
+
+          <ReportSection number="4" title="Організаційна робота" hours={preview.section6.organizationalHours}>
+            <OrganizationalWorkTable rows={preview.section4} />
+          </ReportSection>
+
+          <ReportSection number="5" title="Інші трудові обов'язки" hours={preview.section6.otherHours}>
+            <OtherDutiesTable rows={preview.section5} />
+          </ReportSection>
+
+          <ReportSection
+            number="6"
+            title="Зведена інформація"
+            hours={preview.section6.totalHours}
+            summaryText={`${formatNumber(preview.section6.totalHours, 0)} год. · ${preview.header.totalEmploymentRate} ст.`}
+          >
+            <SummaryTable preview={preview} />
+          </ReportSection>
+        </div>
+
+        <div className="border-neutral-divider mt-2 flex flex-col items-start justify-between gap-3 rounded-[10px] border bg-white px-4 py-4 sm:flex-row sm:items-center">
+          <p className="m-0 text-[14px] leading-[18px]">
+            <span className="font-semibold text-neutral-900">
+              Загальне навантаження: {formatNumber(preview.section6.totalHours, 0)} год.
+            </span>
+            <span className="font-medium text-neutral-500">
+              {' '}
+              · Розрахункова ставка: {preview.header.totalEmploymentRate} ст.
+            </span>
+          </p>
+          <DownloadPdfButton />
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/src/app/[locale]/(k-reports)/k-7/preview/page.tsx
+++ b/src/app/[locale]/(k-reports)/k-7/preview/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+
+import { getK7FormPreview } from '@/actions/k7-form.actions';
+
+import { K7PreviewContent } from './page.content';
+
+interface Props {
+  searchParams: Promise<{ requestId?: string }>;
+}
+
+export default async function K7PreviewPage({ searchParams }: Props) {
+  const { requestId } = await searchParams;
+
+  if (!requestId) notFound();
+
+  const preview = await getK7FormPreview(requestId);
+
+  return <K7PreviewContent preview={preview} />;
+}

--- a/src/app/[locale]/(k-reports)/k-7/preview/utils/group-other-activities.ts
+++ b/src/app/[locale]/(k-reports)/k-7/preview/utils/group-other-activities.ts
@@ -1,0 +1,22 @@
+import { K7OtherEducationalActivity } from '@/types/models/k7-form';
+
+export interface OtherActivityGroup {
+  workType: string;
+  rows: K7OtherEducationalActivity[];
+}
+
+export const groupOtherActivities = (rows: K7OtherEducationalActivity[]): OtherActivityGroup[] =>
+  Array.from(
+    rows.reduce((groups, row) => {
+      const groupRows = groups.get(row.workType);
+
+      if (groupRows) {
+        groupRows.push(row);
+      } else {
+        groups.set(row.workType, [row]);
+      }
+
+      return groups;
+    }, new Map<string, K7OtherEducationalActivity[]>()),
+    ([workType, groupRows]) => ({ workType, rows: groupRows }),
+  );

--- a/src/types/models/k7-form.ts
+++ b/src/types/models/k7-form.ts
@@ -39,3 +39,121 @@ export interface K7ReportRequest {
   requestedAt: string;
   completedAt: string | null;
 }
+
+export interface K7TeachingDiscipline {
+  employeeCategory: string;
+  employeeId: number;
+  departmentId: number;
+  position: string;
+  salary: number;
+  subjectName: string;
+  streamId: string;
+  groupCodes: string;
+  totalVolume: number;
+  practiceGroupsCount: number;
+  labGroupsCount: number;
+  totalStudents: number;
+  lectures: number;
+  practical: number;
+  labs: number;
+  exams: number;
+  credits: number;
+  modularControls: number;
+  individualTasks: number;
+  courseworkChecking: number;
+  courseworkDefense: number;
+  consultations: number;
+  year: number;
+  semester: number;
+}
+
+export const K7_EDUCATION_LEVEL = {
+  Bachelor: 'Bachelor',
+  MasterProfessional: 'MasterProfessional',
+  MasterScientific: 'MasterScientific',
+  PhD: 'PhD',
+  Other: 'Other',
+} as const;
+
+export type K7EducationLevel = (typeof K7_EDUCATION_LEVEL)[keyof typeof K7_EDUCATION_LEVEL];
+
+export interface K7OtherEducationalActivity {
+  employeeCategory: string;
+  employeeId: number;
+  departmentId: number;
+  position: string;
+  salary: number;
+  workType: string;
+  educationLevel: K7EducationLevel;
+  course: number | null;
+  groupCodesSem1: string | null;
+  studentCountSem1: number;
+  hoursSem1: number;
+  groupCodesSem2: string | null;
+  studentCountSem2: number;
+  hoursSem2: number;
+  grandTotal: number;
+  year: number;
+}
+
+export const K7_ACHIEVEMENT_WORK_TYPE = {
+  Scientific: 'Scientific',
+  Methodical: 'Methodical',
+  Organizational: 'Organizational',
+  Other: 'Other',
+  Syllabus: 'Syllabus',
+  Article: 'Article',
+} as const;
+
+export type K7AchievementWorkType = (typeof K7_ACHIEVEMENT_WORK_TYPE)[keyof typeof K7_ACHIEVEMENT_WORK_TYPE];
+
+export interface K7DetailedAchievement {
+  employeeCategory: string;
+  employeeId: number;
+  departmentId: number;
+  position: string;
+  salary: number;
+  workType: K7AchievementWorkType;
+  workTypeDescription: string;
+  workDescription: string;
+  hoursUsed: number;
+  proofOfPerformance: string | null;
+  responsibleDepartment: string | null;
+  year: number;
+  semester: number | null;
+}
+
+export interface K7HtmlPreview {
+  header: {
+    k7ReportRequestId: string;
+    year: number;
+    fullName: string;
+    departmentName: string;
+    position: string;
+    totalEmploymentRate: number;
+    employeeCategory: string;
+  };
+  section1: {
+    teachingDisciplines: K7TeachingDiscipline[];
+    otherEducationalActivities: K7OtherEducationalActivity[];
+  };
+  section2: K7DetailedAchievement[];
+  section3: K7DetailedAchievement[];
+  section4: K7DetailedAchievement[];
+  section5: K7DetailedAchievement[];
+  section6: {
+    educationalHours: number;
+    scientificHours: number;
+    methodicalHours: number;
+    organizationalHours: number;
+    otherHours: number;
+    totalHours: number;
+  };
+}
+
+export interface K7ReportRequestDetails {
+  header: K7HtmlPreview['header'];
+  teachingDisciplines: K7TeachingDiscipline[];
+  otherEducationalActivities: K7OtherEducationalActivity[];
+  detailedAchievements: K7DetailedAchievement[];
+}


### PR DESCRIPTION
This pull request implements the core UI and data transformation logic for the K-7 report preview feature. It introduces a normalization function to process the backend response into a frontend-friendly format, adds a new API action for fetching report previews, and creates several reusable, well-structured table components for rendering different sections of the report. Additionally, it includes a collapsible report section component and a placeholder for PDF download functionality.

**Data transformation and fetching:**

* Added `normalizeK7FormPreview` to convert backend K-7 report data into a structured format for the UI, including grouping achievements by work type and calculating summary hours.
* Introduced `getK7FormPreview` action to fetch and normalize a single K-7 report preview from the backend.

**UI components for report sections:**

* Added table components for rendering various report sections:
  - `DepartmentWorkTable` for departmental work ([src/app/[locale]/(k-reports)/k-7/preview/components/department-work-table.tsxR1-R65](diffhunk://#diff-39149885cc33a8209a08217bad63586c9e0c937462ea18702a0b4e2d98b2136dR1-R65))
  - `MethodicalWorkTable` for methodical work ([src/app/[locale]/(k-reports)/k-7/preview/components/methodical-work-table.tsxR1-R60](diffhunk://#diff-6d36881ef31144bc4c5c4ec72389a6d4209340530e9863210b7386f2657f6e9bR1-R60))
  - `OrganizationalWorkTable` and `ScientificWorkTable` as wrappers around `DepartmentWorkTable` ([src/app/[locale]/(k-reports)/k-7/preview/components/organizational-work-table.tsxR1-R9](diffhunk://#diff-18a869c79184784e8c5c4b234f1cb2d062a3f02d0394262a075a8806b25f40baR1-R9), [src/app/[locale]/(k-reports)/k-7/preview/components/scientific-work-table.tsxR1-R9](diffhunk://#diff-fc2e8a43beca6fd58b1cfbb4bfe19e1409e2713877659e25e2addae93351cc22R1-R9))
  - `OtherActivitiesTable` for other educational activities, with grouping and semester breakdown ([src/app/[locale]/(k-reports)/k-7/preview/components/other-activities-table.tsxR1-R135](diffhunk://#diff-12553f983920e3d3a9681527421631bc9d6723d69e5e8534326263f00d397ce5R1-R135))
  - `OtherDutiesTable` for miscellaneous duties ([src/app/[locale]/(k-reports)/k-7/preview/components/other-duties-table.tsxR1-R55](diffhunk://#diff-f5aa5b0fd84b9d4df4a35b9ea12d59342e253fe0f2d13cce5504470ef9d8b28fR1-R55))
  - `SummaryTable` for displaying the overall workload summary ([src/app/[locale]/(k-reports)/k-7/preview/components/summary-table.tsxR1-R44](diffhunk://#diff-0c225dc9cb2bb10bd411cd8690e3824cca1fed6ed08ff1bf74baea0dedecddcaR1-R44))
  - `EmptyTableRow` for consistent empty state handling in tables ([src/app/[locale]/(k-reports)/k-7/preview/components/empty-table-row.tsxR1-R13](diffhunk://#diff-678e74d4b311b001d3c90b6718d1e100308c5276145d9640fcf373ca0d60bebeR1-R13))

**UI/UX improvements:**

* Added a reusable, collapsible `ReportSection` component for organizing report content with expand/collapse functionality. ([src/app/[locale]/(k-reports)/k-7/preview/components/report-section.tsxR1-R41](diffhunk://#diff-58b0d95c252732385f22c36b3e9a6beba10f14d41eac6eee82ce100ba5501803R1-R41))
* Added a placeholder `DownloadPdfButton` component for future PDF export functionality. ([src/app/[locale]/(k-reports)/k-7/preview/components/download-pdf-button.tsxR1-R19](diffhunk://#diff-feab5730ef91a972fe7a9b0b7bd9963fc998bf49f37a315d0e95cb6ca146a84aR1-R19))