### PR TITLE
KBX-1067 Show the department in the K-7 lecturer profile options

### DIFF
--- a/src/app/[locale]/(private)/module/k7-form/components/k7-report-filters.tsx
+++ b/src/app/[locale]/(private)/module/k7-form/components/k7-report-filters.tsx
@@ -149,7 +149,7 @@ export const K7ReportFilters = ({ filters, reports, departmentProfiles, type }: 
                     key={`${profile.userAccountId}-${profile.employeeId}-${profile.departmentId}-${profile.position}`}
                     value={index.toString()}
                   >
-                    {profile.fullName} - {profile.position}
+                    {profile.fullName} - {profile.departmentName} - {profile.position}
                   </SelectItem>
                 ))
               : filters.profiles.map((profile, index) => (


### PR DESCRIPTION
Jira: [KBX-1067](https://kpiua.atlassian.net/browse/KBX-1067)

## Summary
- Show the department in the department head's K-7 lecturer profile select, so a lecturer holding the same position at two departments no longer renders as two identical options.

## Notes
- No backend change: GET /k7-form/filters already returns departmentName, and the personal tab already labelled its options with it.
- This covers the reported duplicate entries only. The merge cases described in the issue are tracked there; affected records and the supporting data are in Jira.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KBX-1067]: https://kpiua.atlassian.net/browse/KBX-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ